### PR TITLE
feat(demos): add EPCIS-driven DPP master-data demo (battery + textile)

### DIFF
--- a/demos/epcis-driven-dpp/.gitignore
+++ b/demos/epcis-driven-dpp/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env.local
+.env

--- a/demos/epcis-driven-dpp/README.md
+++ b/demos/epcis-driven-dpp/README.md
@@ -1,0 +1,203 @@
+# EPCIS-driven DPP master-data demo
+
+Four runnable flows that prove an OpenEPCIS DPP-Ready deployment can:
+
+1. **register** GTIN/GLN identifiers in a GS1 conformant Digital Link
+   Resolver (DLR) with their master data, and
+2. **update** the registered DPP master data via captured EPCIS 2.0
+   events flowing through the existing Kafka-based message infrastructure.
+
+Everything is plain JSON-LD over GS1 Web Vocabulary + GS1 EPCIS 2.0 — no
+SAMM, no proprietary side-payloads. The same master-data documents are
+served by the DLR and spliced into events as `masterDataAvailableFor`.
+
+## The four flows
+
+| Flow | Event | What it shows |
+|---|---|---|
+| `battery-commission` | `ObjectEvent` ADD, bizStep `commissioning` | First sighting of `https://id.gs1.org/01/09521234000013/21/BAT2024-001` — registers GTIN + GLN + manufacturer in the DLR, splices the same card into the event under `masterDataAvailableFor`, plus initial sensor readings |
+| `battery-state-of-health` | `ObjectEvent` OBSERVE, bizStep `inspecting` | Lifecycle update on the same battery — no `masterDataAvailableFor` (already registered), updated SoH/SoC/cycleCount on `sensorElementList` mutate the DPP |
+| `textile-garment-transform` | `TransformationEvent` | Three input lots (fabric / down / trim) → finished garment; registers the garment GTIN with `textile:textileCategory`, `textile:apparelSubcategory`, `textile:fabricType`, `gs1:textileMaterial` composition |
+| `textile-durability` | `ObjectEvent` OBSERVE, bizStep `inspecting` | Laboratory test result — `textile:robustnessAssessment` carried at event level (per the §2B rule) updates the garment DPP |
+
+All flows use GS1 demo prefix `952` (GCP `9521234`), matching the
+existing examples in `extensions/eu/battery/epcis/` and
+`extensions/eu/textile/epcis/`.
+
+## How it fits together
+
+```
+flows/<flow>.input.json       ──► tools.openepcis.io  ──► out/<flow>.raw.jsonld
+                                                                  │
+flows/<flow>.masterdata.jsonld ─┐                                 │
+                                ├─► merge-masterdata.ts ──────────┤
+                                │                                 ▼
+                                │                       out/<flow>.final.jsonld
+                                │                                 │
+                                │                                 ▼
+                                │             api.epcis.local:8443/capture
+                                │                  (with GS1-Extensions header)
+                                │                                 │
+                                │                                 ▼
+                                │                       Kafka ── OpenSearch
+                                │
+                                └─► seed-dlr.ts ──► id.epcis.local:8443
+                                                          (Product + LinkSet)
+```
+
+The same `*.masterdata.jsonld` sidecar feeds both the DLR seed (as
+served via content-negotiation on the GS1 Digital Link) and the
+`masterDataAvailableFor` block inside the captured event.
+
+> Why the merge step exists at all: the public testdata-generator's
+> input DTO has no `masterDataAvailableFor` field. It supports `@context`
+> overrides, `ilmd`, `userExtensions[].rawJsonld`, `sensorElementList`,
+> and structured WHO/WHERE/WHY fields, but master data is post-processed.
+
+## Prerequisites
+
+The demo targets the local **Colima Kubernetes** deployment of
+`openepcis-platform`. Bring the cluster up once before running flows:
+
+1. Follow `epcis.cloud-dev/openepcis-platform/docs/local-development.md`:
+   `colima start --kubernetes …`, `mkcert -install`, edit
+   `environments/local/terraform.tfvars`, `tofu apply`,
+   `./scripts/dev/port-forward.sh openepcis`.
+2. Add the `/etc/hosts` entries from `env/hosts.example`.
+3. Confirm `https://api.epcis.local:8443/q/health` and
+   `https://id.epcis.local:8443/q/health` answer 200.
+
+Then in this directory:
+
+```bash
+pnpm install
+cp env/local.env.example .env.local   # adjust if your endpoints differ
+```
+
+## Running
+
+End-to-end (seed-dlr → generate → merge → capture → verify):
+
+```bash
+pnpm demo:battery:commission
+pnpm demo:battery:soh
+pnpm demo:textile:transform
+pnpm demo:textile:durability
+# or all four:
+pnpm demo:all
+```
+
+Smoke-test against `tools.openepcis.io` only (no cluster needed —
+useful for iterating on the input templates):
+
+```bash
+SKIP_CLUSTER=1 pnpm demo:battery:commission
+ls out/    # battery-commission.raw.jsonld, battery-commission.final.jsonld
+```
+
+Individual stages (each accepts an optional flow name; default is all):
+
+```bash
+pnpm generate battery-commission
+pnpm merge battery-commission
+pnpm seed-dlr battery-commission
+pnpm capture battery-commission
+pnpm verify battery-commission
+```
+
+## What the merge step does
+
+`scripts/merge-masterdata.ts` reads the sidecar, transforms each card
+under `masterData[]`, and assigns the result to
+`event.masterDataAvailableFor` on every event in the generated document.
+
+The transform follows
+[`extensions/common/core/docs/EPCIS_MASTERDATA_AND_EXTENSIONS.md`](../../extensions/common/core/docs/EPCIS_MASTERDATA_AND_EXTENSIONS.md)
+§2A: keys prefixed with `gs1:` are emitted **bare** inside an EPCIS
+event (they resolve via the EPCIS context's `@vocab`); keys with other
+prefixes (`battery:`, `textile:`, `dpp:`) **keep** their prefix.
+
+The sidecar itself uses `gs1:` prefixes everywhere because it's served
+as a stand-alone WebVoc-pattern master-data file from the DLR (Angle 2 of
+the doc above), not embedded in an EPCIS context.
+
+## Verifying
+
+`scripts/verify.ts` runs per-flow checks and logs `[PASS]` / `[FAIL]`
+per step:
+
+- DLR round-trip: `GET /<digital-link>?linkType=gs1:masterData` returns
+  the registered card.
+- Repository query: `GET /events?MATCH_anyEPC=<epc>` returns the captured
+  event(s) for the EPC.
+
+Additional verification you can run by hand:
+
+```bash
+# JSON-LD expansion (zero orphan keys)
+npx -y jsonld expand out/battery-commission.final.jsonld | jq .
+
+# Diff against the committed example
+diff <(jq -S '.epcisBody.eventList[0]' out/battery-commission.final.jsonld) \
+     <(jq -S '.epcisBody.eventList[0]' ../../extensions/eu/battery/epcis/commissioning.jsonld)
+
+# Battery-Pass v1.3 conformance harness on the merged event
+cd ../..
+npx tsx scripts/test-batterypass-conformance.ts demos/epcis-driven-dpp/out/battery-commission.final.jsonld
+```
+
+## Loading a flow into the Test Data Designer UI
+
+Each `flows/<flow>.input.json` (the API DTO) is auto-converted by
+`scripts/to-designer.ts` into `flows/designer/<flow>.designer.json` —
+the Drawflow-design shape that
+`https://tools.openepcis.io/ui/event-data-designer/?url=<raw-url>` loads.
+The conversion runs as the last step of every `pnpm demo:*` command, so
+the designer files stay in sync with the API templates.
+
+Push the branch, then open these URLs in a browser
+(`pnpm designer-urls` prints them; override repo/branch with
+`REPO_OWNER=… REPO_BRANCH=…`):
+
+| Flow | Designer URL |
+|---|---|
+| battery-commission | `https://tools.openepcis.io/ui/event-data-designer/?url=https://raw.githubusercontent.com/openepcis/openepcis-dpp-ready/main/demos/epcis-driven-dpp/flows/designer/battery-commission.designer.json` |
+| battery-state-of-health | …`/battery-state-of-health.designer.json` |
+| textile-garment-transform | …`/textile-garment-transform.designer.json` |
+| textile-durability | …`/textile-durability.designer.json` |
+
+When the URL loads, you should see identifier nodes wired into a single
+event node on the Drawflow canvas; clicking the event opens the same
+WHO/WHERE/WHY editor the GS1 Implementation-Guideline templates use.
+Hitting **Generate** in the UI produces an EPCIS document equivalent to
+`out/<flow>.raw.jsonld` (i.e. without `masterDataAvailableFor`, which our
+local merge step still has to splice in).
+
+## Layout
+
+```
+demos/epcis-driven-dpp/
+├── flows/
+│   ├── battery-commission.input.json          # testdata-gen API template
+│   ├── battery-commission.masterdata.jsonld   # sidecar (= DLR record)
+│   ├── battery-state-of-health.input.json
+│   ├── textile-garment-transform.input.json
+│   ├── textile-garment-transform.masterdata.jsonld
+│   ├── textile-durability.input.json
+│   └── designer/                              # Drawflow-design shape
+│       └── *.designer.json                    # auto-generated; uploadable to UI
+├── scripts/
+│   ├── generate.ts             # POST template to tools.openepcis.io
+│   ├── merge-masterdata.ts     # splice masterDataAvailableFor
+│   ├── to-designer.ts          # convert API template → Drawflow-design shape
+│   ├── designer-urls.ts        # print Designer UI URLs for the flows
+│   ├── seed-dlr.ts             # Product + LinkSet to local DLR
+│   ├── capture.ts              # POST to /capture with GS1-Extensions
+│   ├── verify.ts               # read-back assertions
+│   ├── run-flow.ts             # orchestrate one flow end-to-end
+│   └── lib/{env,io,http,keycloak}.ts
+├── env/
+│   ├── local.env.example
+│   └── hosts.example
+└── out/                        # generated artefacts (.gitignored)
+```

--- a/demos/epcis-driven-dpp/env/hosts.example
+++ b/demos/epcis-driven-dpp/env/hosts.example
@@ -1,0 +1,7 @@
+# Append to /etc/hosts so the local Colima k3s ingress hostnames resolve.
+# Required for the Keycloak / capture / DLR URLs in env/local.env.example.
+# (Same set documented in openepcis-platform/docs/local-development.md.)
+
+127.0.0.1 api.epcis.local
+127.0.0.1 id.epcis.local
+127.0.0.1 auth.epcis.local

--- a/demos/epcis-driven-dpp/env/local.env.example
+++ b/demos/epcis-driven-dpp/env/local.env.example
@@ -1,0 +1,26 @@
+# Copy to demos/epcis-driven-dpp/.env.local and adjust if your hosts differ.
+# Defaults match openepcis-platform/docs/local-development.md (Colima k3s + Traefik).
+
+# Public test data generator
+TESTDATA_GENERATOR_URL=https://tools.openepcis.io/api/generateTestData
+
+# Local cluster endpoints (Traefik on Colima k3s, port-forwarded by
+# openepcis-platform/scripts/dev/port-forward.sh)
+EPCIS_API_URL=https://api.epcis.local:8443
+DLR_URL=https://id.epcis.local:8443
+KEYCLOAK_URL=https://auth.epcis.local:8443
+
+# Keycloak realm + demo client (defaults from local-development.md)
+KEYCLOAK_REALM=openepcis-dev
+KEYCLOAK_CLIENT_ID=backend-service
+KEYCLOAK_CLIENT_SECRET=dev-secret-change-me
+KEYCLOAK_USERNAME=admin
+KEYCLOAK_PASSWORD=admin
+
+# Local mkcert root is trusted system-wide; flip to 1 only if you must skip TLS verify
+INSECURE_TLS=0
+
+# Kafka topic the capture-service emits onto (for read-back / verify step).
+# kafka-console-consumer is invoked via kubectl exec in scripts/verify.ts.
+KAFKA_TOPIC=epcis.events.captured
+KAFKA_NAMESPACE=openepcis

--- a/demos/epcis-driven-dpp/flows/battery-commission.input.json
+++ b/demos/epcis-driven-dpp/flows/battery-commission.input.json
@@ -1,0 +1,132 @@
+{
+  "_comment": "Flow B1 — battery commission. ObjectEvent ADD bizStep=commissioning. Generates the EPCIS skeleton; scripts/merge-masterdata.ts adds masterDataAvailableFor from battery-commission.masterdata.jsonld. Mirrors extensions/eu/battery/epcis/commissioning.jsonld.",
+  "events": [
+    {
+      "nodeId": 100,
+      "eventType": "ObjectEvent",
+      "eventCount": 1,
+      "ordinaryEvent": true,
+      "action": "ADD",
+      "businessStep": "COMMISSIONING",
+      "disposition": "ACTIVE",
+      "locationPartyIdentifierSyntax": "WebURI",
+      "dlURL": "https://id.gs1.org",
+      "eventID": true,
+      "eventIdType": "UUID",
+      "eventTime": {
+        "specificTime": "2024-03-15T14:30:00.000+01:00",
+        "timeZoneOffset": "+01:00"
+      },
+      "readPoint": {
+        "type": "SGLN",
+        "gln": "9521234000013",
+        "gcpLength": 7
+      },
+      "bizLocation": {
+        "type": "SGLN",
+        "gln": "9521234000013",
+        "gcpLength": 7
+      },
+      "bizTransactions": [
+        {
+          "type": "prodorder",
+          "bizTransaction": "https://ecocell-batteries.example.com/orders/PO-2024-00142"
+        }
+      ],
+      "sources": [
+        {
+          "type": "OWNING_PARTY",
+          "glnType": "PGLN",
+          "gln": "9521234000006",
+          "gcpLength": 7
+        }
+      ],
+      "destinations": [
+        {
+          "type": "OWNING_PARTY",
+          "glnType": "PGLN",
+          "gln": "9521234000006",
+          "gcpLength": 7
+        }
+      ],
+      "referencedIdentifier": [
+        {
+          "identifierId": 1,
+          "epcCount": 1,
+          "inheritParentCount": 0,
+          "classCount": 0,
+          "quantity": 0
+        }
+      ],
+      "userExtensions": [
+        {
+          "rawJsonld": {
+            "sensorElementList": [
+              {
+                "sensorMetadata": {
+                  "time": "2024-03-15T14:30:00.000Z",
+                  "deviceID": "https://id.gs1.org/8004/9521234EOL-TEST-001"
+                },
+                "sensorReport": [
+                  {
+                    "type": "battery:stateOfHealth",
+                    "value": 100,
+                    "uom": "P1",
+                    "measurementMethod": "Initial factory test"
+                  },
+                  {
+                    "type": "battery:stateOfCharge",
+                    "value": 50,
+                    "uom": "P1"
+                  },
+                  {
+                    "type": "battery:cycleCount",
+                    "value": 0
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "parentReferencedIdentifier": {},
+      "outputReferencedIdentifier": []
+    }
+  ],
+  "identifiers": [
+    {
+      "identifierId": 1,
+      "objectIdentifierSyntax": "WebURI",
+      "dlURL": "https://id.gs1.org",
+      "instanceData": {
+        "sgtin": {
+          "identifierType": "sgtin",
+          "serialType": "none",
+          "sgtin": "09521234000013",
+          "serialNumber": "BAT2024-001"
+        }
+      },
+      "classData": null,
+      "parentData": null
+    }
+  ],
+  "contextUrls": [
+    {
+      "ID": 1,
+      "prefix": "battery",
+      "contextURL": "https://ref.openepcis.io/extensions/eu/battery/",
+      "isChecked": true,
+      "contextFetchURL": "https://ref.openepcis.io/extensions/eu/battery/battery-context.jsonld",
+      "selected": true
+    },
+    {
+      "ID": 2,
+      "prefix": "dpp",
+      "contextURL": "https://ref.openepcis.io/extensions/common/core/",
+      "isChecked": true,
+      "contextFetchURL": "https://ref.openepcis.io/extensions/common/core/dpp-core-context.jsonld",
+      "selected": true
+    }
+  ],
+  "randomGenerators": []
+}

--- a/demos/epcis-driven-dpp/flows/battery-commission.masterdata.jsonld
+++ b/demos/epcis-driven-dpp/flows/battery-commission.masterdata.jsonld
@@ -1,0 +1,75 @@
+{
+  "_comment_architecture": [
+    "Sidecar master data for the battery-commission flow.",
+    "Single source of truth between two consumers:",
+    "  1. scripts/seed-dlr.ts — PUTs each masterData[i] entry as a DLR Product / Place / Organization record",
+    "     (id maps to the GS1 Digital Link being seeded). Plus a LinkSet entry with link type",
+    "     gs1:masterData pointing at a self-referential href so GET /<dl>?linkType=masterData returns",
+    "     this card inline (200 rather than redirect).",
+    "  2. scripts/merge-masterdata.ts — splices masterData[] into the generated EPCIS event under",
+    "     event.masterDataAvailableFor, stripping the gs1: prefix from keys per",
+    "     extensions/common/core/docs/EPCIS_MASTERDATA_AND_EXTENSIONS.md §2A. battery: / dpp: prefixes",
+    "     are kept (those aren't elided by the EPCIS context).",
+    "Mirrors the masterDataAvailableFor block in extensions/eu/battery/epcis/commissioning.jsonld."
+  ],
+  "@context": [
+    "https://ref.openepcis.io/extensions/common/core/dpp-core-context.jsonld",
+    "https://ref.openepcis.io/extensions/eu/battery/battery-context.jsonld",
+    { "gs1": "https://ref.gs1.org/voc/" }
+  ],
+  "masterData": [
+    {
+      "id": "https://id.gs1.org/01/09521234000013/21/BAT2024-001",
+      "type": "gs1:Product",
+      "gs1:productName": { "en": "EcoCell Industrial Battery Module IM-500" },
+      "gs1:gtin": "09521234000013",
+      "gs1:serialNumber": "BAT2024-001",
+      "gs1:brand": { "gs1:brandName": { "en": "EcoCell" } },
+      "gs1:netWeight": { "type": "gs1:WeightKilograms", "value": 125.5 },
+      "gs1:countryOfOrigin": { "gs1:countryCode": "DE" },
+      "gs1:regulatoryInformation": [
+        {
+          "type": "gs1:RegulatoryInformation",
+          "gs1:regulationType": { "id": "RegulationTypeCode-BATTERY_DIRECTIVE" },
+          "gs1:regulatoryAct": "EU 2023/1542"
+        }
+      ],
+      "battery:batteryCategory": "IndustrialBattery",
+      "battery:batteryModelIdentifier": "ECO-IM-500",
+      "battery:batterySerialNumber": "BAT2024-001",
+      "battery:facilityIdentifier": "9521234000013",
+      "battery:operatorIdentifier": "9521234000006",
+      "battery:manufacturerIdentifier": "9521234000006",
+      "battery:batteryChemistry": {
+        "battery:shortName": "LFP",
+        "battery:fullName": "Lithium Iron Phosphate"
+      },
+      "battery:ratedCapacity": { "type": "battery:CapacityAmpereHours", "value": 280 },
+      "battery:ratedEnergy": { "type": "battery:EnergyKilowattHours", "value": 14.3 },
+      "dpp:schemaVersion": "1.3",
+      "dpp:status": "Active",
+      "dpp:granularity": "ItemLevel",
+      "dpp:lastUpdate": "2024-03-15T14:30:00.000Z"
+    },
+    {
+      "id": "https://id.gs1.org/414/9521234000013",
+      "type": "gs1:Place",
+      "gs1:locationGLN": "9521234000013",
+      "gs1:physicalLocationName": { "en": "EcoCell GmbH - Production Facility" },
+      "gs1:address": {
+        "type": "gs1:PostalAddress",
+        "gs1:streetAddress": "Batteriestrasse 42",
+        "gs1:addressLocality": "Stuttgart",
+        "gs1:postalCode": "70173",
+        "gs1:countryCode": "DE"
+      }
+    },
+    {
+      "id": "https://id.gs1.org/417/9521234000006",
+      "type": "gs1:Organization",
+      "gs1:partyGLN": "9521234000006",
+      "gs1:organizationName": { "en": "EcoCell GmbH" },
+      "gs1:countryCode": "DE"
+    }
+  ]
+}

--- a/demos/epcis-driven-dpp/flows/battery-state-of-health.input.json
+++ b/demos/epcis-driven-dpp/flows/battery-state-of-health.input.json
@@ -1,0 +1,110 @@
+{
+  "_comment": "Flow B2 — battery lifecycle update. ObjectEvent OBSERVE bizStep=inspecting on the same EPC commissioned in B1. No masterDataAvailableFor in the merged output (already registered in DLR). Updated SoH/SoC/cycleCount carried in sensorElementList demonstrate event-driven DPP master-data updates. Mirrors extensions/eu/battery/epcis/state-of-health.jsonld.",
+  "events": [
+    {
+      "nodeId": 100,
+      "eventType": "ObjectEvent",
+      "eventCount": 1,
+      "ordinaryEvent": true,
+      "action": "OBSERVE",
+      "businessStep": "INSPECTING",
+      "disposition": "IN_PROGRESS",
+      "locationPartyIdentifierSyntax": "WebURI",
+      "dlURL": "https://id.gs1.org",
+      "eventID": true,
+      "eventIdType": "UUID",
+      "eventTime": {
+        "specificTime": "2026-04-29T09:15:00.000+02:00",
+        "timeZoneOffset": "+02:00"
+      },
+      "readPoint": {
+        "type": "SGLN",
+        "gln": "9521234000037",
+        "gcpLength": 7
+      },
+      "bizLocation": {
+        "type": "SGLN",
+        "gln": "9521234000037",
+        "gcpLength": 7
+      },
+      "referencedIdentifier": [
+        {
+          "identifierId": 1,
+          "epcCount": 1,
+          "inheritParentCount": 0,
+          "classCount": 0,
+          "quantity": 0
+        }
+      ],
+      "userExtensions": [
+        {
+          "rawJsonld": {
+            "sensorElementList": [
+              {
+                "sensorMetadata": {
+                  "time": "2026-04-29T09:15:00.000+02:00",
+                  "deviceID": "https://id.gs1.org/8004/9521234SOH-RIG-007"
+                },
+                "sensorReport": [
+                  {
+                    "type": "battery:stateOfHealth",
+                    "value": 92.4,
+                    "uom": "P1",
+                    "measurementMethod": "IEC 62660-3 capacity check"
+                  },
+                  {
+                    "type": "battery:stateOfCharge",
+                    "value": 78,
+                    "uom": "P1"
+                  },
+                  {
+                    "type": "battery:cycleCount",
+                    "value": 312
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "parentReferencedIdentifier": {},
+      "outputReferencedIdentifier": []
+    }
+  ],
+  "identifiers": [
+    {
+      "identifierId": 1,
+      "objectIdentifierSyntax": "WebURI",
+      "dlURL": "https://id.gs1.org",
+      "instanceData": {
+        "sgtin": {
+          "identifierType": "sgtin",
+          "serialType": "none",
+          "sgtin": "09521234000013",
+          "serialNumber": "BAT2024-001"
+        }
+      },
+      "classData": null,
+      "parentData": null
+    }
+  ],
+  "contextUrls": [
+    {
+      "ID": 1,
+      "prefix": "battery",
+      "contextURL": "https://ref.openepcis.io/extensions/eu/battery/",
+      "isChecked": true,
+      "contextFetchURL": "https://ref.openepcis.io/extensions/eu/battery/battery-context.jsonld",
+      "selected": true
+    },
+    {
+      "ID": 2,
+      "prefix": "dpp",
+      "contextURL": "https://ref.openepcis.io/extensions/common/core/",
+      "isChecked": true,
+      "contextFetchURL": "https://ref.openepcis.io/extensions/common/core/dpp-core-context.jsonld",
+      "selected": true
+    }
+  ],
+  "randomGenerators": []
+}

--- a/demos/epcis-driven-dpp/flows/designer/battery-commission.designer.json
+++ b/demos/epcis-driven-dpp/flows/designer/battery-commission.designer.json
@@ -1,0 +1,235 @@
+{
+  "eventNodeInfo": [
+    {
+      "eventId": 100,
+      "eventType": "ObjectEvent",
+      "eventInfo": {
+        "objectIdentifierSyntax": "WebURI",
+        "locationPartyIdentifierSyntax": "WebURI",
+        "dlURL": "https://id.gs1.org",
+        "eventCount": 1,
+        "eventTime": {
+          "timeSelector": "SpecificTime",
+          "specificTime": "2024-03-15T14:30:00.000+01:00",
+          "fromTime": "2024-03-15T14:30:00.000+01:00",
+          "toTime": "2024-03-15T14:30:00.000+01:00",
+          "timeZoneOffset": "+01:00"
+        },
+        "parentIdentifier": [],
+        "instanceIdentifier": [],
+        "classIdentifier": [],
+        "outputInstanceIdentifier": [],
+        "outputClassIdentifier": [],
+        "readPoint": {
+          "type": "SGLN",
+          "gln": "9521234000013",
+          "gcpLength": 7
+        },
+        "bizLocation": {
+          "type": "SGLN",
+          "gln": "9521234000013",
+          "gcpLength": 7
+        },
+        "persistentDispositionList": [],
+        "bizTransactions": [
+          {
+            "type": "prodorder",
+            "bizTransaction": "https://ecocell-batteries.example.com/orders/PO-2024-00142"
+          }
+        ],
+        "sources": [
+          {
+            "type": "OWNING_PARTY",
+            "glnType": "PGLN",
+            "gln": "9521234000006",
+            "gcpLength": 7
+          }
+        ],
+        "destinations": [
+          {
+            "type": "OWNING_PARTY",
+            "glnType": "PGLN",
+            "gln": "9521234000006",
+            "gcpLength": 7
+          }
+        ],
+        "sensorElementList": [],
+        "userExtensions": [
+          {
+            "rawJsonld": {
+              "sensorElementList": [
+                {
+                  "sensorMetadata": {
+                    "time": "2024-03-15T14:30:00.000Z",
+                    "deviceID": "https://id.gs1.org/8004/9521234EOL-TEST-001"
+                  },
+                  "sensorReport": [
+                    {
+                      "type": "battery:stateOfHealth",
+                      "value": 100,
+                      "uom": "P1",
+                      "measurementMethod": "Initial factory test"
+                    },
+                    {
+                      "type": "battery:stateOfCharge",
+                      "value": 50,
+                      "uom": "P1"
+                    },
+                    {
+                      "type": "battery:cycleCount",
+                      "value": 0
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "certificationInfo": [],
+        "ilmd": [],
+        "errorDeclaration": {
+          "declarationTime": {
+            "timeSelector": "SpecificTime",
+            "specificTime": "2024-03-15T14:30:00.000+01:00",
+            "fromTime": "2024-03-15T14:30:00.000+01:00",
+            "toTime": "2024-03-15T14:30:00.000+01:00",
+            "timeZoneOffset": "+01:00"
+          },
+          "correctiveIds": [],
+          "extensions": [],
+          "declarationReason": "DID_NOT_OCCUR"
+        },
+        "eventType": "ObjectEvent",
+        "ordinaryEvent": true,
+        "eventID": true,
+        "eventIdType": "UUID",
+        "recordTimeOption": "No",
+        "action": "ADD",
+        "businessStep": "COMMISSIONING",
+        "disposition": "ACTIVE",
+        "referencedIdentifier": [
+          {
+            "identifierId": 1,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+          }
+        ],
+        "parentReferencedIdentifier": {},
+        "outputReferencedIdentifier": [],
+        "name": "battery-commission (event 100)",
+        "description": "Auto-converted from flows/battery-commission.input.json"
+      }
+    }
+  ],
+  "identifiersNodeInfo": [
+    {
+      "identifiersId": 1,
+      "identifierType": "Identifiers",
+      "objectIdentifierSyntax": "WebURI",
+      "dlURL": "https://id.gs1.org",
+      "instanceType": "sgtin",
+      "instanceData": {
+        "identifierType": "sgtin",
+        "serialType": "none",
+        "sgtin": "09521234000013",
+        "serialNumber": "BAT2024-001"
+      }
+    }
+  ],
+  "connectorsInfo": [
+    {
+      "ID": 1,
+      "name": "connector1",
+      "source": "1",
+      "target": "100",
+      "hideInheritParentCount": false,
+      "epcCount": 1,
+      "inheritParentCount": 0,
+      "classCount": 0,
+      "quantity": 0
+    }
+  ],
+  "drawflowInfo": {
+    "drawflow": {
+      "Home": {
+        "data": {
+          "1": {
+            "id": 1,
+            "name": "Identifiers",
+            "data": {
+              "ID": 1,
+              "eventType": "Identifiers"
+            },
+            "class": "Identifiers",
+            "html": "Identifiers",
+            "typenode": "vue",
+            "inputs": {},
+            "outputs": {
+              "output_1": {
+                "connections": [
+                  {
+                    "node": "100",
+                    "output": "input_1"
+                  }
+                ]
+              }
+            },
+            "pos_x": 200,
+            "pos_y": 100
+          },
+          "100": {
+            "id": 100,
+            "name": "Events",
+            "data": {
+              "ID": 100,
+              "eventType": "ObjectEvent"
+            },
+            "class": "ObjectEvent",
+            "html": "Events",
+            "typenode": "vue",
+            "inputs": {
+              "input_1": {
+                "connections": [
+                  {
+                    "node": "1",
+                    "input": "output_1"
+                  }
+                ]
+              },
+              "input_2": {
+                "connections": []
+              }
+            },
+            "outputs": {
+              "output_1": {
+                "connections": []
+              }
+            },
+            "pos_x": 800,
+            "pos_y": 200
+          }
+        }
+      }
+    }
+  },
+  "contextUrls": [
+    {
+      "ID": 1,
+      "prefix": "battery",
+      "contextURL": "https://ref.openepcis.io/extensions/eu/battery/",
+      "isChecked": true,
+      "contextFetchURL": "https://ref.openepcis.io/extensions/eu/battery/battery-context.jsonld",
+      "selected": true
+    },
+    {
+      "ID": 2,
+      "prefix": "dpp",
+      "contextURL": "https://ref.openepcis.io/extensions/common/core/",
+      "isChecked": true,
+      "contextFetchURL": "https://ref.openepcis.io/extensions/common/core/dpp-core-context.jsonld",
+      "selected": true
+    }
+  ]
+}

--- a/demos/epcis-driven-dpp/flows/designer/battery-state-of-health.designer.json
+++ b/demos/epcis-driven-dpp/flows/designer/battery-state-of-health.designer.json
@@ -1,0 +1,216 @@
+{
+  "eventNodeInfo": [
+    {
+      "eventId": 100,
+      "eventType": "ObjectEvent",
+      "eventInfo": {
+        "objectIdentifierSyntax": "WebURI",
+        "locationPartyIdentifierSyntax": "WebURI",
+        "dlURL": "https://id.gs1.org",
+        "eventCount": 1,
+        "eventTime": {
+          "timeSelector": "SpecificTime",
+          "specificTime": "2026-04-29T09:15:00.000+02:00",
+          "fromTime": "2026-04-29T09:15:00.000+02:00",
+          "toTime": "2026-04-29T09:15:00.000+02:00",
+          "timeZoneOffset": "+02:00"
+        },
+        "parentIdentifier": [],
+        "instanceIdentifier": [],
+        "classIdentifier": [],
+        "outputInstanceIdentifier": [],
+        "outputClassIdentifier": [],
+        "readPoint": {
+          "type": "SGLN",
+          "gln": "9521234000037",
+          "gcpLength": 7
+        },
+        "bizLocation": {
+          "type": "SGLN",
+          "gln": "9521234000037",
+          "gcpLength": 7
+        },
+        "persistentDispositionList": [],
+        "bizTransactions": [],
+        "sources": [],
+        "destinations": [],
+        "sensorElementList": [],
+        "userExtensions": [
+          {
+            "rawJsonld": {
+              "sensorElementList": [
+                {
+                  "sensorMetadata": {
+                    "time": "2026-04-29T09:15:00.000+02:00",
+                    "deviceID": "https://id.gs1.org/8004/9521234SOH-RIG-007"
+                  },
+                  "sensorReport": [
+                    {
+                      "type": "battery:stateOfHealth",
+                      "value": 92.4,
+                      "uom": "P1",
+                      "measurementMethod": "IEC 62660-3 capacity check"
+                    },
+                    {
+                      "type": "battery:stateOfCharge",
+                      "value": 78,
+                      "uom": "P1"
+                    },
+                    {
+                      "type": "battery:cycleCount",
+                      "value": 312
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "certificationInfo": [],
+        "ilmd": [],
+        "errorDeclaration": {
+          "declarationTime": {
+            "timeSelector": "SpecificTime",
+            "specificTime": "2026-04-29T09:15:00.000+02:00",
+            "fromTime": "2026-04-29T09:15:00.000+02:00",
+            "toTime": "2026-04-29T09:15:00.000+02:00",
+            "timeZoneOffset": "+02:00"
+          },
+          "correctiveIds": [],
+          "extensions": [],
+          "declarationReason": "DID_NOT_OCCUR"
+        },
+        "eventType": "ObjectEvent",
+        "ordinaryEvent": true,
+        "eventID": true,
+        "eventIdType": "UUID",
+        "recordTimeOption": "No",
+        "action": "OBSERVE",
+        "businessStep": "INSPECTING",
+        "disposition": "IN_PROGRESS",
+        "referencedIdentifier": [
+          {
+            "identifierId": 1,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+          }
+        ],
+        "parentReferencedIdentifier": {},
+        "outputReferencedIdentifier": [],
+        "name": "battery-state-of-health (event 100)",
+        "description": "Auto-converted from flows/battery-state-of-health.input.json"
+      }
+    }
+  ],
+  "identifiersNodeInfo": [
+    {
+      "identifiersId": 1,
+      "identifierType": "Identifiers",
+      "objectIdentifierSyntax": "WebURI",
+      "dlURL": "https://id.gs1.org",
+      "instanceType": "sgtin",
+      "instanceData": {
+        "identifierType": "sgtin",
+        "serialType": "none",
+        "sgtin": "09521234000013",
+        "serialNumber": "BAT2024-001"
+      }
+    }
+  ],
+  "connectorsInfo": [
+    {
+      "ID": 1,
+      "name": "connector1",
+      "source": "1",
+      "target": "100",
+      "hideInheritParentCount": false,
+      "epcCount": 1,
+      "inheritParentCount": 0,
+      "classCount": 0,
+      "quantity": 0
+    }
+  ],
+  "drawflowInfo": {
+    "drawflow": {
+      "Home": {
+        "data": {
+          "1": {
+            "id": 1,
+            "name": "Identifiers",
+            "data": {
+              "ID": 1,
+              "eventType": "Identifiers"
+            },
+            "class": "Identifiers",
+            "html": "Identifiers",
+            "typenode": "vue",
+            "inputs": {},
+            "outputs": {
+              "output_1": {
+                "connections": [
+                  {
+                    "node": "100",
+                    "output": "input_1"
+                  }
+                ]
+              }
+            },
+            "pos_x": 200,
+            "pos_y": 100
+          },
+          "100": {
+            "id": 100,
+            "name": "Events",
+            "data": {
+              "ID": 100,
+              "eventType": "ObjectEvent"
+            },
+            "class": "ObjectEvent",
+            "html": "Events",
+            "typenode": "vue",
+            "inputs": {
+              "input_1": {
+                "connections": [
+                  {
+                    "node": "1",
+                    "input": "output_1"
+                  }
+                ]
+              },
+              "input_2": {
+                "connections": []
+              }
+            },
+            "outputs": {
+              "output_1": {
+                "connections": []
+              }
+            },
+            "pos_x": 800,
+            "pos_y": 200
+          }
+        }
+      }
+    }
+  },
+  "contextUrls": [
+    {
+      "ID": 1,
+      "prefix": "battery",
+      "contextURL": "https://ref.openepcis.io/extensions/eu/battery/",
+      "isChecked": true,
+      "contextFetchURL": "https://ref.openepcis.io/extensions/eu/battery/battery-context.jsonld",
+      "selected": true
+    },
+    {
+      "ID": 2,
+      "prefix": "dpp",
+      "contextURL": "https://ref.openepcis.io/extensions/common/core/",
+      "isChecked": true,
+      "contextFetchURL": "https://ref.openepcis.io/extensions/common/core/dpp-core-context.jsonld",
+      "selected": true
+    }
+  ]
+}

--- a/demos/epcis-driven-dpp/flows/designer/textile-durability.designer.json
+++ b/demos/epcis-driven-dpp/flows/designer/textile-durability.designer.json
@@ -1,0 +1,200 @@
+{
+  "eventNodeInfo": [
+    {
+      "eventId": 100,
+      "eventType": "ObjectEvent",
+      "eventInfo": {
+        "objectIdentifierSyntax": "WebURI",
+        "locationPartyIdentifierSyntax": "WebURI",
+        "dlURL": "https://id.gs1.org",
+        "eventCount": 1,
+        "eventTime": {
+          "timeSelector": "SpecificTime",
+          "specificTime": "2026-02-12T14:00:00.000+01:00",
+          "fromTime": "2026-02-12T14:00:00.000+01:00",
+          "toTime": "2026-02-12T14:00:00.000+01:00",
+          "timeZoneOffset": "+01:00"
+        },
+        "parentIdentifier": [],
+        "instanceIdentifier": [],
+        "classIdentifier": [],
+        "outputInstanceIdentifier": [],
+        "outputClassIdentifier": [],
+        "readPoint": {
+          "type": "SGLN",
+          "gln": "9521234000044",
+          "gcpLength": 7
+        },
+        "bizLocation": {
+          "type": "SGLN",
+          "gln": "9521234000044",
+          "gcpLength": 7
+        },
+        "persistentDispositionList": [],
+        "bizTransactions": [],
+        "sources": [],
+        "destinations": [],
+        "sensorElementList": [],
+        "userExtensions": [
+          {
+            "rawJsonld": {
+              "textile:robustnessAssessment": {
+                "type": "textile:RobustnessAssessment",
+                "textile:assessmentMethod": "ISO 12947-2 Martindale abrasion",
+                "textile:abrasionCycles": 32000,
+                "textile:colourFastnessRating": 4,
+                "textile:robustnessScore": 78,
+                "textile:assessmentLab": "https://id.gs1.org/417/9521234000044",
+                "textile:assessmentDate": "2026-02-12"
+              }
+            }
+          }
+        ],
+        "certificationInfo": [],
+        "ilmd": [],
+        "errorDeclaration": {
+          "declarationTime": {
+            "timeSelector": "SpecificTime",
+            "specificTime": "2026-02-12T14:00:00.000+01:00",
+            "fromTime": "2026-02-12T14:00:00.000+01:00",
+            "toTime": "2026-02-12T14:00:00.000+01:00",
+            "timeZoneOffset": "+01:00"
+          },
+          "correctiveIds": [],
+          "extensions": [],
+          "declarationReason": "DID_NOT_OCCUR"
+        },
+        "eventType": "ObjectEvent",
+        "ordinaryEvent": true,
+        "eventID": true,
+        "eventIdType": "UUID",
+        "recordTimeOption": "No",
+        "action": "OBSERVE",
+        "businessStep": "INSPECTING",
+        "disposition": "IN_PROGRESS",
+        "referencedIdentifier": [
+          {
+            "identifierId": 1,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+          }
+        ],
+        "parentReferencedIdentifier": {},
+        "outputReferencedIdentifier": [],
+        "name": "textile-durability (event 100)",
+        "description": "Auto-converted from flows/textile-durability.input.json"
+      }
+    }
+  ],
+  "identifiersNodeInfo": [
+    {
+      "identifiersId": 1,
+      "identifierType": "Identifiers",
+      "objectIdentifierSyntax": "WebURI",
+      "dlURL": "https://id.gs1.org",
+      "instanceType": "sgtin",
+      "instanceData": {
+        "identifierType": "sgtin",
+        "serialType": "none",
+        "sgtin": "09521234000020",
+        "serialNumber": "WJ-2025-00301"
+      }
+    }
+  ],
+  "connectorsInfo": [
+    {
+      "ID": 1,
+      "name": "connector1",
+      "source": "1",
+      "target": "100",
+      "hideInheritParentCount": false,
+      "epcCount": 1,
+      "inheritParentCount": 0,
+      "classCount": 0,
+      "quantity": 0
+    }
+  ],
+  "drawflowInfo": {
+    "drawflow": {
+      "Home": {
+        "data": {
+          "1": {
+            "id": 1,
+            "name": "Identifiers",
+            "data": {
+              "ID": 1,
+              "eventType": "Identifiers"
+            },
+            "class": "Identifiers",
+            "html": "Identifiers",
+            "typenode": "vue",
+            "inputs": {},
+            "outputs": {
+              "output_1": {
+                "connections": [
+                  {
+                    "node": "100",
+                    "output": "input_1"
+                  }
+                ]
+              }
+            },
+            "pos_x": 200,
+            "pos_y": 100
+          },
+          "100": {
+            "id": 100,
+            "name": "Events",
+            "data": {
+              "ID": 100,
+              "eventType": "ObjectEvent"
+            },
+            "class": "ObjectEvent",
+            "html": "Events",
+            "typenode": "vue",
+            "inputs": {
+              "input_1": {
+                "connections": [
+                  {
+                    "node": "1",
+                    "input": "output_1"
+                  }
+                ]
+              },
+              "input_2": {
+                "connections": []
+              }
+            },
+            "outputs": {
+              "output_1": {
+                "connections": []
+              }
+            },
+            "pos_x": 800,
+            "pos_y": 200
+          }
+        }
+      }
+    }
+  },
+  "contextUrls": [
+    {
+      "ID": 1,
+      "prefix": "textile",
+      "contextURL": "https://ref.openepcis.io/extensions/eu/textile/",
+      "isChecked": true,
+      "contextFetchURL": "https://ref.openepcis.io/extensions/eu/textile/textile-context.jsonld",
+      "selected": true
+    },
+    {
+      "ID": 2,
+      "prefix": "dpp",
+      "contextURL": "https://ref.openepcis.io/extensions/common/core/",
+      "isChecked": true,
+      "contextFetchURL": "https://ref.openepcis.io/extensions/common/core/dpp-core-context.jsonld",
+      "selected": true
+    }
+  ]
+}

--- a/demos/epcis-driven-dpp/flows/designer/textile-garment-transform.designer.json
+++ b/demos/epcis-driven-dpp/flows/designer/textile-garment-transform.designer.json
@@ -1,0 +1,373 @@
+{
+  "eventNodeInfo": [
+    {
+      "eventId": 100,
+      "eventType": "TransformationEvent",
+      "eventInfo": {
+        "objectIdentifierSyntax": "WebURI",
+        "locationPartyIdentifierSyntax": "WebURI",
+        "dlURL": "https://id.gs1.org",
+        "eventCount": 1,
+        "eventTime": {
+          "timeSelector": "SpecificTime",
+          "specificTime": "2025-09-18T10:00:00.000+01:00",
+          "fromTime": "2025-09-18T10:00:00.000+01:00",
+          "toTime": "2025-09-18T10:00:00.000+01:00",
+          "timeZoneOffset": "+01:00"
+        },
+        "parentIdentifier": [],
+        "instanceIdentifier": [],
+        "classIdentifier": [],
+        "outputInstanceIdentifier": [],
+        "outputClassIdentifier": [],
+        "readPoint": {
+          "type": "SGLN",
+          "gln": "9521234000020",
+          "gcpLength": 7
+        },
+        "bizLocation": {
+          "type": "SGLN",
+          "gln": "9521234000020",
+          "gcpLength": 7
+        },
+        "persistentDispositionList": [],
+        "bizTransactions": [],
+        "sources": [],
+        "destinations": [],
+        "sensorElementList": [],
+        "userExtensions": [],
+        "certificationInfo": [],
+        "ilmd": [],
+        "errorDeclaration": {
+          "declarationTime": {
+            "timeSelector": "SpecificTime",
+            "specificTime": "2025-09-18T10:00:00.000+01:00",
+            "fromTime": "2025-09-18T10:00:00.000+01:00",
+            "toTime": "2025-09-18T10:00:00.000+01:00",
+            "timeZoneOffset": "+01:00"
+          },
+          "correctiveIds": [],
+          "extensions": [],
+          "declarationReason": "DID_NOT_OCCUR"
+        },
+        "eventType": "TransformationEvent",
+        "ordinaryEvent": true,
+        "eventID": true,
+        "eventIdType": "UUID",
+        "recordTimeOption": "No",
+        "businessStep": "COMMISSIONING",
+        "disposition": "ACTIVE",
+        "referencedIdentifier": [
+          {
+            "identifierId": 1,
+            "epcCount": 0,
+            "inheritParentCount": 0,
+            "classCount": 1,
+            "quantity": 1
+          },
+          {
+            "identifierId": 2,
+            "epcCount": 0,
+            "inheritParentCount": 0,
+            "classCount": 1,
+            "quantity": 1
+          },
+          {
+            "identifierId": 3,
+            "epcCount": 0,
+            "inheritParentCount": 0,
+            "classCount": 1,
+            "quantity": 1
+          }
+        ],
+        "parentReferencedIdentifier": {},
+        "outputReferencedIdentifier": [
+          {
+            "identifierId": 4,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+          }
+        ],
+        "name": "textile-garment-transform (event 100)",
+        "description": "Auto-converted from flows/textile-garment-transform.input.json"
+      }
+    }
+  ],
+  "identifiersNodeInfo": [
+    {
+      "identifiersId": 1,
+      "identifierType": "Identifiers",
+      "objectIdentifierSyntax": "WebURI",
+      "dlURL": "https://id.gs1.org",
+      "classType": "lgtin",
+      "classData": {
+        "identifierType": "lgtin",
+        "quantityType": "Variable Measure Quantity",
+        "serialType": "none",
+        "lgtin": "09521234000136",
+        "serialNumber": "FABRIC-WJ-2025-015",
+        "quantity": 1,
+        "uom": "MTR"
+      }
+    },
+    {
+      "identifiersId": 2,
+      "identifierType": "Identifiers",
+      "objectIdentifierSyntax": "WebURI",
+      "dlURL": "https://id.gs1.org",
+      "classType": "lgtin",
+      "classData": {
+        "identifierType": "lgtin",
+        "quantityType": "Variable Measure Quantity",
+        "serialType": "none",
+        "lgtin": "09521234000143",
+        "serialNumber": "DOWN-RDS-2025-007",
+        "quantity": 1,
+        "uom": "KGM"
+      }
+    },
+    {
+      "identifiersId": 3,
+      "identifierType": "Identifiers",
+      "objectIdentifierSyntax": "WebURI",
+      "dlURL": "https://id.gs1.org",
+      "classType": "lgtin",
+      "classData": {
+        "identifierType": "lgtin",
+        "quantityType": "Variable Measure Quantity",
+        "serialType": "none",
+        "lgtin": "09521234000150",
+        "serialNumber": "TRIM-ZIP-2025-100",
+        "quantity": 1,
+        "uom": "C62"
+      }
+    },
+    {
+      "identifiersId": 4,
+      "identifierType": "Identifiers",
+      "objectIdentifierSyntax": "WebURI",
+      "dlURL": "https://id.gs1.org",
+      "instanceType": "sgtin",
+      "instanceData": {
+        "identifierType": "sgtin",
+        "serialType": "none",
+        "sgtin": "09521234000020",
+        "serialNumber": "WJ-2025-00301"
+      }
+    }
+  ],
+  "connectorsInfo": [
+    {
+      "ID": 1,
+      "name": "connector1",
+      "source": "1",
+      "target": "100",
+      "hideInheritParentCount": false,
+      "epcCount": 0,
+      "inheritParentCount": 0,
+      "classCount": 1,
+      "quantity": 1
+    },
+    {
+      "ID": 2,
+      "name": "connector2",
+      "source": "2",
+      "target": "100",
+      "hideInheritParentCount": false,
+      "epcCount": 0,
+      "inheritParentCount": 0,
+      "classCount": 1,
+      "quantity": 1
+    },
+    {
+      "ID": 3,
+      "name": "connector3",
+      "source": "3",
+      "target": "100",
+      "hideInheritParentCount": false,
+      "epcCount": 0,
+      "inheritParentCount": 0,
+      "classCount": 1,
+      "quantity": 1
+    },
+    {
+      "ID": 4,
+      "name": "connector4",
+      "source": "4",
+      "target": "100",
+      "hideInheritParentCount": false,
+      "epcCount": 1,
+      "inheritParentCount": 0,
+      "classCount": 0,
+      "quantity": 0
+    }
+  ],
+  "drawflowInfo": {
+    "drawflow": {
+      "Home": {
+        "data": {
+          "1": {
+            "id": 1,
+            "name": "Identifiers",
+            "data": {
+              "ID": 1,
+              "eventType": "Identifiers"
+            },
+            "class": "Identifiers",
+            "html": "Identifiers",
+            "typenode": "vue",
+            "inputs": {},
+            "outputs": {
+              "output_1": {
+                "connections": [
+                  {
+                    "node": "100",
+                    "output": "input_1"
+                  }
+                ]
+              }
+            },
+            "pos_x": 200,
+            "pos_y": 100
+          },
+          "2": {
+            "id": 2,
+            "name": "Identifiers",
+            "data": {
+              "ID": 2,
+              "eventType": "Identifiers"
+            },
+            "class": "Identifiers",
+            "html": "Identifiers",
+            "typenode": "vue",
+            "inputs": {},
+            "outputs": {
+              "output_1": {
+                "connections": [
+                  {
+                    "node": "100",
+                    "output": "input_1"
+                  }
+                ]
+              }
+            },
+            "pos_x": 200,
+            "pos_y": 220
+          },
+          "3": {
+            "id": 3,
+            "name": "Identifiers",
+            "data": {
+              "ID": 3,
+              "eventType": "Identifiers"
+            },
+            "class": "Identifiers",
+            "html": "Identifiers",
+            "typenode": "vue",
+            "inputs": {},
+            "outputs": {
+              "output_1": {
+                "connections": [
+                  {
+                    "node": "100",
+                    "output": "input_1"
+                  }
+                ]
+              }
+            },
+            "pos_x": 200,
+            "pos_y": 340
+          },
+          "4": {
+            "id": 4,
+            "name": "Identifiers",
+            "data": {
+              "ID": 4,
+              "eventType": "Identifiers"
+            },
+            "class": "Identifiers",
+            "html": "Identifiers",
+            "typenode": "vue",
+            "inputs": {},
+            "outputs": {
+              "output_1": {
+                "connections": [
+                  {
+                    "node": "100",
+                    "output": "input_2"
+                  }
+                ]
+              }
+            },
+            "pos_x": 200,
+            "pos_y": 460
+          },
+          "100": {
+            "id": 100,
+            "name": "Events",
+            "data": {
+              "ID": 100,
+              "eventType": "TransformationEvent"
+            },
+            "class": "TransformationEvent",
+            "html": "Events",
+            "typenode": "vue",
+            "inputs": {
+              "input_1": {
+                "connections": [
+                  {
+                    "node": "1",
+                    "input": "output_1"
+                  },
+                  {
+                    "node": "2",
+                    "input": "output_1"
+                  },
+                  {
+                    "node": "3",
+                    "input": "output_1"
+                  }
+                ]
+              },
+              "input_2": {
+                "connections": [
+                  {
+                    "node": "4",
+                    "input": "output_1"
+                  }
+                ]
+              }
+            },
+            "outputs": {
+              "output_1": {
+                "connections": []
+              }
+            },
+            "pos_x": 800,
+            "pos_y": 200
+          }
+        }
+      }
+    }
+  },
+  "contextUrls": [
+    {
+      "ID": 1,
+      "prefix": "textile",
+      "contextURL": "https://ref.openepcis.io/extensions/eu/textile/",
+      "isChecked": true,
+      "contextFetchURL": "https://ref.openepcis.io/extensions/eu/textile/textile-context.jsonld",
+      "selected": true
+    },
+    {
+      "ID": 2,
+      "prefix": "dpp",
+      "contextURL": "https://ref.openepcis.io/extensions/common/core/",
+      "isChecked": true,
+      "contextFetchURL": "https://ref.openepcis.io/extensions/common/core/dpp-core-context.jsonld",
+      "selected": true
+    }
+  ]
+}

--- a/demos/epcis-driven-dpp/flows/textile-durability.input.json
+++ b/demos/epcis-driven-dpp/flows/textile-durability.input.json
@@ -1,0 +1,94 @@
+{
+  "_comment": "Flow T2 — textile lifecycle observation. ObjectEvent OBSERVE bizStep=inspecting on the garment commissioned in T1. Carries a textile:robustnessAssessment block at event level (per EPCIS_MASTERDATA_AND_EXTENSIONS.md §2B — laboratory test results belong at event level, NOT in masterDataAvailableFor). Mirrors extensions/eu/textile/epcis/observation-durability.jsonld.",
+  "events": [
+    {
+      "nodeId": 100,
+      "eventType": "ObjectEvent",
+      "eventCount": 1,
+      "ordinaryEvent": true,
+      "action": "OBSERVE",
+      "businessStep": "INSPECTING",
+      "disposition": "IN_PROGRESS",
+      "locationPartyIdentifierSyntax": "WebURI",
+      "dlURL": "https://id.gs1.org",
+      "eventID": true,
+      "eventIdType": "UUID",
+      "eventTime": {
+        "specificTime": "2026-02-12T14:00:00.000+01:00",
+        "timeZoneOffset": "+01:00"
+      },
+      "readPoint": {
+        "type": "SGLN",
+        "gln": "9521234000044",
+        "gcpLength": 7
+      },
+      "bizLocation": {
+        "type": "SGLN",
+        "gln": "9521234000044",
+        "gcpLength": 7
+      },
+      "referencedIdentifier": [
+        {
+          "identifierId": 1,
+          "epcCount": 1,
+          "inheritParentCount": 0,
+          "classCount": 0,
+          "quantity": 0
+        }
+      ],
+      "userExtensions": [
+        {
+          "rawJsonld": {
+            "textile:robustnessAssessment": {
+              "type": "textile:RobustnessAssessment",
+              "textile:assessmentMethod": "ISO 12947-2 Martindale abrasion",
+              "textile:abrasionCycles": 32000,
+              "textile:colourFastnessRating": 4,
+              "textile:robustnessScore": 78,
+              "textile:assessmentLab": "https://id.gs1.org/417/9521234000044",
+              "textile:assessmentDate": "2026-02-12"
+            }
+          }
+        }
+      ],
+      "parentReferencedIdentifier": {},
+      "outputReferencedIdentifier": []
+    }
+  ],
+  "identifiers": [
+    {
+      "identifierId": 1,
+      "objectIdentifierSyntax": "WebURI",
+      "dlURL": "https://id.gs1.org",
+      "instanceData": {
+        "sgtin": {
+          "identifierType": "sgtin",
+          "serialType": "none",
+          "sgtin": "09521234000020",
+          "serialNumber": "WJ-2025-00301"
+        }
+      },
+      "classData": null,
+      "parentData": null
+    }
+  ],
+  "contextUrls": [
+    {
+      "ID": 1,
+      "prefix": "textile",
+      "contextURL": "https://ref.openepcis.io/extensions/eu/textile/",
+      "isChecked": true,
+      "contextFetchURL": "https://ref.openepcis.io/extensions/eu/textile/textile-context.jsonld",
+      "selected": true
+    },
+    {
+      "ID": 2,
+      "prefix": "dpp",
+      "contextURL": "https://ref.openepcis.io/extensions/common/core/",
+      "isChecked": true,
+      "contextFetchURL": "https://ref.openepcis.io/extensions/common/core/dpp-core-context.jsonld",
+      "selected": true
+    }
+  ],
+  "randomGenerators": []
+}

--- a/demos/epcis-driven-dpp/flows/textile-garment-transform.input.json
+++ b/demos/epcis-driven-dpp/flows/textile-garment-transform.input.json
@@ -1,0 +1,154 @@
+{
+  "_comment": "Flow T1 — textile garment transformation. TransformationEvent commissions a finished garment GTIN from three input lots (fabric / down / trim). Mirrors extensions/eu/textile/epcis/transformation-garment.jsonld. masterDataAvailableFor (with textileCategory / apparelSubcategory / fabricType / gs1:textileMaterial) is added by scripts/merge-masterdata.ts.",
+  "events": [
+    {
+      "nodeId": 100,
+      "eventType": "TransformationEvent",
+      "eventCount": 1,
+      "ordinaryEvent": true,
+      "businessStep": "COMMISSIONING",
+      "disposition": "ACTIVE",
+      "locationPartyIdentifierSyntax": "WebURI",
+      "dlURL": "https://id.gs1.org",
+      "eventID": true,
+      "eventIdType": "UUID",
+      "eventTime": {
+        "specificTime": "2025-09-18T10:00:00.000+01:00",
+        "timeZoneOffset": "+01:00"
+      },
+      "readPoint": {
+        "type": "SGLN",
+        "gln": "9521234000020",
+        "gcpLength": 7
+      },
+      "bizLocation": {
+        "type": "SGLN",
+        "gln": "9521234000020",
+        "gcpLength": 7
+      },
+      "referencedIdentifier": [
+        {
+          "identifierId": 1,
+          "epcCount": 0,
+          "inheritParentCount": 0,
+          "classCount": 1,
+          "quantity": 1
+        },
+        {
+          "identifierId": 2,
+          "epcCount": 0,
+          "inheritParentCount": 0,
+          "classCount": 1,
+          "quantity": 1
+        },
+        {
+          "identifierId": 3,
+          "epcCount": 0,
+          "inheritParentCount": 0,
+          "classCount": 1,
+          "quantity": 1
+        }
+      ],
+      "outputReferencedIdentifier": [
+        {
+          "identifierId": 4,
+          "epcCount": 1,
+          "inheritParentCount": 0,
+          "classCount": 0,
+          "quantity": 0
+        }
+      ],
+      "parentReferencedIdentifier": {}
+    }
+  ],
+  "identifiers": [
+    {
+      "identifierId": 1,
+      "objectIdentifierSyntax": "WebURI",
+      "dlURL": "https://id.gs1.org",
+      "instanceData": null,
+      "classData": {
+        "lgtin": {
+          "identifierType": "lgtin",
+          "quantityType": "Variable Measure Quantity",
+          "serialType": "none",
+          "lgtin": "09521234000136",
+          "serialNumber": "FABRIC-WJ-2025-015",
+          "quantity": 1,
+          "uom": "MTR"
+        }
+      },
+      "parentData": null
+    },
+    {
+      "identifierId": 2,
+      "objectIdentifierSyntax": "WebURI",
+      "dlURL": "https://id.gs1.org",
+      "instanceData": null,
+      "classData": {
+        "lgtin": {
+          "identifierType": "lgtin",
+          "quantityType": "Variable Measure Quantity",
+          "serialType": "none",
+          "lgtin": "09521234000143",
+          "serialNumber": "DOWN-RDS-2025-007",
+          "quantity": 1,
+          "uom": "KGM"
+        }
+      },
+      "parentData": null
+    },
+    {
+      "identifierId": 3,
+      "objectIdentifierSyntax": "WebURI",
+      "dlURL": "https://id.gs1.org",
+      "instanceData": null,
+      "classData": {
+        "lgtin": {
+          "identifierType": "lgtin",
+          "quantityType": "Variable Measure Quantity",
+          "serialType": "none",
+          "lgtin": "09521234000150",
+          "serialNumber": "TRIM-ZIP-2025-100",
+          "quantity": 1,
+          "uom": "C62"
+        }
+      },
+      "parentData": null
+    },
+    {
+      "identifierId": 4,
+      "objectIdentifierSyntax": "WebURI",
+      "dlURL": "https://id.gs1.org",
+      "instanceData": {
+        "sgtin": {
+          "identifierType": "sgtin",
+          "serialType": "none",
+          "sgtin": "09521234000020",
+          "serialNumber": "WJ-2025-00301"
+        }
+      },
+      "classData": null,
+      "parentData": null
+    }
+  ],
+  "contextUrls": [
+    {
+      "ID": 1,
+      "prefix": "textile",
+      "contextURL": "https://ref.openepcis.io/extensions/eu/textile/",
+      "isChecked": true,
+      "contextFetchURL": "https://ref.openepcis.io/extensions/eu/textile/textile-context.jsonld",
+      "selected": true
+    },
+    {
+      "ID": 2,
+      "prefix": "dpp",
+      "contextURL": "https://ref.openepcis.io/extensions/common/core/",
+      "isChecked": true,
+      "contextFetchURL": "https://ref.openepcis.io/extensions/common/core/dpp-core-context.jsonld",
+      "selected": true
+    }
+  ],
+  "randomGenerators": []
+}

--- a/demos/epcis-driven-dpp/flows/textile-garment-transform.masterdata.jsonld
+++ b/demos/epcis-driven-dpp/flows/textile-garment-transform.masterdata.jsonld
@@ -1,0 +1,82 @@
+{
+  "_comment_architecture": [
+    "Sidecar master data for the textile-garment-transform flow.",
+    "Mirrors the masterDataAvailableFor block in",
+    "extensions/eu/textile/epcis/transformation-garment.jsonld.",
+    "textile:textileCategory / apparelSubcategory / fabricType describe the GTIN itself",
+    "(identical for every lot of this SKU) and therefore belong in the product master data card,",
+    "not in ilmd."
+  ],
+  "@context": [
+    "https://ref.openepcis.io/extensions/common/core/dpp-core-context.jsonld",
+    "https://ref.openepcis.io/extensions/eu/textile/textile-context.jsonld",
+    { "gs1": "https://ref.gs1.org/voc/" }
+  ],
+  "masterData": [
+    {
+      "id": "https://id.gs1.org/01/09521234000020/21/WJ-2025-00301",
+      "type": "gs1:Product",
+      "gs1:productName": { "en": "Alpine Pro Winter Jacket - Navy" },
+      "gs1:gtin": "09521234000020",
+      "gs1:serialNumber": "WJ-2025-00301",
+      "gs1:brand": { "gs1:brandName": { "en": "Alpine Pro" } },
+      "gs1:countryOfOrigin": { "gs1:countryCode": "PT" },
+      "gs1:textileMaterial": [
+        {
+          "type": "gs1:TextileMaterialDetails",
+          "gs1:textileMaterialContent": {
+            "type": "gs1:QuantitativeValue",
+            "gs1:unitCode": "P1",
+            "value": 55
+          },
+          "gs1:textileMaterialDescription": { "en": "Recycled Polyester (Shell)" }
+        },
+        {
+          "type": "gs1:TextileMaterialDetails",
+          "gs1:textileMaterialContent": {
+            "type": "gs1:QuantitativeValue",
+            "gs1:unitCode": "P1",
+            "value": 25
+          },
+          "gs1:textileMaterialDescription": { "en": "Down (Insulation - RDS Certified)" }
+        },
+        {
+          "type": "gs1:TextileMaterialDetails",
+          "gs1:textileMaterialContent": {
+            "type": "gs1:QuantitativeValue",
+            "gs1:unitCode": "P1",
+            "value": 15
+          },
+          "gs1:textileMaterialDescription": { "en": "Polyamide (Lining)" }
+        },
+        {
+          "type": "gs1:TextileMaterialDetails",
+          "gs1:textileMaterialContent": {
+            "type": "gs1:QuantitativeValue",
+            "gs1:unitCode": "P1",
+            "value": 5
+          },
+          "gs1:textileMaterialDescription": { "en": "Elastane (Cuffs)" }
+        }
+      ],
+      "textile:textileCategory": "Apparel",
+      "textile:apparelSubcategory": "JacketsCoats",
+      "textile:fabricType": "WovenNonDenim",
+      "dpp:schemaVersion": "1.0",
+      "dpp:status": "Active",
+      "dpp:granularity": "ItemLevel",
+      "dpp:lastUpdate": "2025-09-18T10:00:00.000Z"
+    },
+    {
+      "id": "https://id.gs1.org/414/9521234000020",
+      "type": "gs1:Place",
+      "gs1:locationGLN": "9521234000020",
+      "gs1:physicalLocationName": { "en": "Porto Textile Manufacturing" },
+      "gs1:address": {
+        "type": "gs1:PostalAddress",
+        "gs1:addressLocality": "Porto",
+        "gs1:countryCode": "PT"
+      }
+    }
+  ]
+}

--- a/demos/epcis-driven-dpp/out/.gitignore
+++ b/demos/epcis-driven-dpp/out/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/demos/epcis-driven-dpp/package.json
+++ b/demos/epcis-driven-dpp/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "openepcis-dpp-epcis-driven-demo",
+  "version": "0.1.0",
+  "private": true,
+  "description": "End-to-end demo: register GTIN/GLN with master data in the DLR and update DPP master data via captured EPCIS events. Targets a local Colima k3s deployment of openepcis-platform.",
+  "type": "module",
+  "scripts": {
+    "demo:battery:commission": "tsx scripts/run-flow.ts battery-commission",
+    "demo:battery:soh": "tsx scripts/run-flow.ts battery-state-of-health",
+    "demo:textile:transform": "tsx scripts/run-flow.ts textile-garment-transform",
+    "demo:textile:durability": "tsx scripts/run-flow.ts textile-durability",
+    "demo:all": "pnpm demo:battery:commission && pnpm demo:battery:soh && pnpm demo:textile:transform && pnpm demo:textile:durability",
+    "to-designer": "tsx scripts/to-designer.ts",
+    "designer-urls": "tsx scripts/designer-urls.ts",
+    "generate": "tsx scripts/generate.ts",
+    "merge": "tsx scripts/merge-masterdata.ts",
+    "seed-dlr": "tsx scripts/seed-dlr.ts",
+    "capture": "tsx scripts/capture.ts",
+    "verify": "tsx scripts/verify.ts"
+  },
+  "dependencies": {
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
+    "undici": "^7.0.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.2",
+    "typescript": "^5.6.3",
+    "@types/node": "^22.10.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/demos/epcis-driven-dpp/pnpm-lock.yaml
+++ b/demos/epcis-driven-dpp/pnpm-lock.yaml
@@ -1,0 +1,401 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      ajv:
+        specifier: ^8.17.1
+        version: 8.20.0
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.20.0)
+      undici:
+        specifier: ^7.0.0
+        version: 7.25.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.17
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@types/node@22.19.17':
+    dependencies:
+      undici-types: 6.21.0
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  json-schema-traverse@1.0.0: {}
+
+  require-from-string@2.0.2: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  undici@7.25.0: {}

--- a/demos/epcis-driven-dpp/scripts/capture.ts
+++ b/demos/epcis-driven-dpp/scripts/capture.ts
@@ -1,0 +1,33 @@
+import { resolve } from 'node:path';
+import { readJson } from './lib/io.js';
+import { httpFetch, expectOk } from './lib/http.js';
+import { getAccessToken } from './lib/keycloak.js';
+import { ALL_FLOWS, GS1_EXTENSIONS_FOR_FLOW, OUT_DIR, getenv, type FlowName } from './lib/env.js';
+
+async function capture(flow: FlowName): Promise<void> {
+  const finalPath = resolve(OUT_DIR, `${flow}.final.jsonld`);
+  const doc = readJson<unknown>(finalPath);
+  const url = `${getenv('EPCIS_API_URL')}/capture`;
+  const token = await getAccessToken();
+
+  const response = await httpFetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/ld+json',
+      'GS1-Extensions': GS1_EXTENSIONS_FOR_FLOW[flow],
+      'GS1-EPCIS-Version': '2.0',
+      'GS1-CBV-Version': '2.0',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(doc),
+  });
+  await expectOk(response, `capture(${flow}) → POST ${url}`);
+
+  const location = response.headers.get('location') ?? '';
+  const eventId = location.split('/').pop() ?? '';
+  console.log(`capture ${flow}: ${response.status} ${response.statusText}  location=${location}  eventId=${eventId}`);
+}
+
+const args = process.argv.slice(2);
+const targets = args.length > 0 ? (args as FlowName[]) : ALL_FLOWS;
+for (const flow of targets) await capture(flow);

--- a/demos/epcis-driven-dpp/scripts/designer-urls.ts
+++ b/demos/epcis-driven-dpp/scripts/designer-urls.ts
@@ -1,0 +1,28 @@
+/**
+ * Print Test Data Designer UI URLs for each flow.
+ *
+ *   https://tools.openepcis.io/ui/event-data-designer/?url=<raw-github-url>
+ *
+ * The URLs only work AFTER `flows/designer/*.designer.json` is pushed to a
+ * public branch. Until then, treat them as templates.
+ *
+ * Override the repo / branch via env: REPO_OWNER, REPO_NAME, REPO_BRANCH,
+ * REPO_PATH (default: demos/epcis-driven-dpp/flows/designer).
+ */
+import { ALL_FLOWS } from './lib/env.js';
+
+const owner = process.env.REPO_OWNER ?? 'openepcis';
+const name = process.env.REPO_NAME ?? 'openepcis-dpp-ready';
+const branch = process.env.REPO_BRANCH ?? 'main';
+const path = process.env.REPO_PATH ?? 'demos/epcis-driven-dpp/flows/designer';
+const designerBase = 'https://tools.openepcis.io/ui/event-data-designer/?url=';
+
+console.log(`# Designer URLs for ${owner}/${name}@${branch}`);
+console.log(`# (URLs only work once the files are pushed)\n`);
+
+for (const flow of ALL_FLOWS) {
+  const raw = `https://raw.githubusercontent.com/${owner}/${name}/${branch}/${path}/${flow}.designer.json`;
+  console.log(`## ${flow}`);
+  console.log(`raw:      ${raw}`);
+  console.log(`designer: ${designerBase}${raw}\n`);
+}

--- a/demos/epcis-driven-dpp/scripts/generate.ts
+++ b/demos/epcis-driven-dpp/scripts/generate.ts
@@ -1,0 +1,25 @@
+import { resolve } from 'node:path';
+import { writeJson, readJson } from './lib/io.js';
+import { httpFetch, expectOk } from './lib/http.js';
+import { ALL_FLOWS, FLOWS_DIR, OUT_DIR, getenv, type FlowName } from './lib/env.js';
+
+async function generate(flow: FlowName): Promise<void> {
+  const inputPath = resolve(FLOWS_DIR, `${flow}.input.json`);
+  const outputPath = resolve(OUT_DIR, `${flow}.raw.jsonld`);
+  const url = getenv('TESTDATA_GENERATOR_URL');
+
+  const input = readJson<Record<string, unknown>>(inputPath);
+  const response = await httpFetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(input),
+  });
+  await expectOk(response, `generate(${flow}) → POST ${url}`);
+  const generated = await response.json();
+  writeJson(outputPath, generated);
+  console.log(`generated ${flow} → ${outputPath}`);
+}
+
+const args = process.argv.slice(2);
+const targets = args.length > 0 ? (args as FlowName[]) : ALL_FLOWS;
+for (const flow of targets) await generate(flow);

--- a/demos/epcis-driven-dpp/scripts/lib/env.ts
+++ b/demos/epcis-driven-dpp/scripts/lib/env.ts
@@ -1,0 +1,66 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+export const DEMO_ROOT = resolve(here, '..', '..');
+export const FLOWS_DIR = resolve(DEMO_ROOT, 'flows');
+export const OUT_DIR = resolve(DEMO_ROOT, 'out');
+
+export type FlowName =
+  | 'battery-commission'
+  | 'battery-state-of-health'
+  | 'textile-garment-transform'
+  | 'textile-durability';
+
+export const ALL_FLOWS: FlowName[] = [
+  'battery-commission',
+  'battery-state-of-health',
+  'textile-garment-transform',
+  'textile-durability',
+];
+
+export const SIDECAR_FOR_FLOW: Record<FlowName, FlowName | null> = {
+  'battery-commission': 'battery-commission',
+  'battery-state-of-health': null,
+  'textile-garment-transform': 'textile-garment-transform',
+  'textile-durability': null,
+};
+
+export const GS1_EXTENSIONS_FOR_FLOW: Record<FlowName, string> = {
+  'battery-commission':
+    'dpp=https://ref.openepcis.io/extensions/common/core/,battery=https://ref.openepcis.io/extensions/eu/battery/',
+  'battery-state-of-health':
+    'dpp=https://ref.openepcis.io/extensions/common/core/,battery=https://ref.openepcis.io/extensions/eu/battery/',
+  'textile-garment-transform':
+    'dpp=https://ref.openepcis.io/extensions/common/core/,textile=https://ref.openepcis.io/extensions/eu/textile/',
+  'textile-durability':
+    'dpp=https://ref.openepcis.io/extensions/common/core/,textile=https://ref.openepcis.io/extensions/eu/textile/',
+};
+
+function loadDotenv(path: string): void {
+  if (!existsSync(path)) return;
+  for (const line of readFileSync(path, 'utf8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq < 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const value = trimmed.slice(eq + 1).trim().replace(/^['"]|['"]$/g, '');
+    if (!(key in process.env)) process.env[key] = value;
+  }
+}
+
+loadDotenv(resolve(DEMO_ROOT, '.env.local'));
+loadDotenv(resolve(DEMO_ROOT, 'env', 'local.env.example'));
+
+export function getenv(name: string, fallback?: string): string {
+  const v = process.env[name];
+  if (v === undefined || v === '') {
+    if (fallback !== undefined) return fallback;
+    throw new Error(`Missing required env var: ${name}`);
+  }
+  return v;
+}
+
+export const TLS_INSECURE = process.env.INSECURE_TLS === '1';

--- a/demos/epcis-driven-dpp/scripts/lib/http.ts
+++ b/demos/epcis-driven-dpp/scripts/lib/http.ts
@@ -1,0 +1,22 @@
+import { Agent, fetch as undiciFetch, type RequestInit } from 'undici';
+import { TLS_INSECURE } from './env.js';
+
+const insecureAgent = TLS_INSECURE
+  ? new Agent({ connect: { rejectUnauthorized: false } })
+  : undefined;
+
+export async function httpFetch(url: string, init: RequestInit = {}): Promise<Response> {
+  const response = await undiciFetch(url, {
+    ...init,
+    dispatcher: insecureAgent,
+  });
+  return response as unknown as Response;
+}
+
+export async function expectOk(response: Response, label: string): Promise<Response> {
+  if (!response.ok) {
+    const body = await response.text().catch(() => '<no body>');
+    throw new Error(`${label} failed (${response.status}): ${body.slice(0, 800)}`);
+  }
+  return response;
+}

--- a/demos/epcis-driven-dpp/scripts/lib/io.ts
+++ b/demos/epcis-driven-dpp/scripts/lib/io.ts
@@ -1,0 +1,11 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+export function readJson<T = unknown>(path: string): T {
+  return JSON.parse(readFileSync(path, 'utf8')) as T;
+}
+
+export function writeJson(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(value, null, 2) + '\n', 'utf8');
+}

--- a/demos/epcis-driven-dpp/scripts/lib/keycloak.ts
+++ b/demos/epcis-driven-dpp/scripts/lib/keycloak.ts
@@ -1,0 +1,40 @@
+import { httpFetch, expectOk } from './http.js';
+import { getenv } from './env.js';
+
+let cachedToken: { value: string; expiresAt: number } | null = null;
+
+export async function getAccessToken(): Promise<string> {
+  if (cachedToken && cachedToken.expiresAt > Date.now() + 30_000) {
+    return cachedToken.value;
+  }
+
+  const base = getenv('KEYCLOAK_URL');
+  const realm = getenv('KEYCLOAK_REALM');
+  const clientId = getenv('KEYCLOAK_CLIENT_ID');
+  const clientSecret = getenv('KEYCLOAK_CLIENT_SECRET');
+  const username = getenv('KEYCLOAK_USERNAME');
+  const password = getenv('KEYCLOAK_PASSWORD');
+
+  const tokenUrl = `${base}/realms/${realm}/protocol/openid-connect/token`;
+  const body = new URLSearchParams({
+    grant_type: 'password',
+    client_id: clientId,
+    client_secret: clientSecret,
+    username,
+    password,
+  });
+
+  const response = await httpFetch(tokenUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+  await expectOk(response, `Keycloak token (${tokenUrl})`);
+  const json = (await response.json()) as { access_token: string; expires_in: number };
+
+  cachedToken = {
+    value: json.access_token,
+    expiresAt: Date.now() + json.expires_in * 1000,
+  };
+  return cachedToken.value;
+}

--- a/demos/epcis-driven-dpp/scripts/merge-masterdata.ts
+++ b/demos/epcis-driven-dpp/scripts/merge-masterdata.ts
@@ -1,0 +1,74 @@
+import { resolve } from 'node:path';
+import { writeJson, readJson } from './lib/io.js';
+import { ALL_FLOWS, FLOWS_DIR, OUT_DIR, SIDECAR_FOR_FLOW, type FlowName } from './lib/env.js';
+
+type MasterDataCard = Record<string, unknown> & { id?: string; type?: string };
+type Sidecar = { masterData?: MasterDataCard[] };
+type EPCISDoc = {
+  '@context'?: unknown;
+  epcisBody?: { eventList?: Record<string, unknown>[] };
+};
+
+const GS1_PREFIX = 'gs1:';
+
+/**
+ * Inside an EPCIS event's masterDataAvailableFor, the EPCIS JSON-LD context's
+ * @vocab makes the gs1: prefix implicit — keys, type-values, and id-values
+ * that were authored as `gs1:Foo` must be emitted bare (`Foo`) so they expand
+ * to the same gs1:Foo IRI without the user having to redeclare the prefix.
+ *
+ * Other prefixes (battery:, textile:, dpp:) MUST keep their prefix:
+ * the EPCIS context does not define them. See
+ * extensions/common/core/docs/EPCIS_MASTERDATA_AND_EXTENSIONS.md §2A.
+ */
+function stripGs1Prefix(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return value.startsWith(GS1_PREFIX) ? value.slice(GS1_PREFIX.length) : value;
+  }
+  if (Array.isArray(value)) return value.map(stripGs1Prefix);
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
+      const newKey = key.startsWith(GS1_PREFIX) ? key.slice(GS1_PREFIX.length) : key;
+      out[newKey] = stripGs1Prefix(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+function transformCardForEvent(card: MasterDataCard): MasterDataCard {
+  return stripGs1Prefix(card) as MasterDataCard;
+}
+
+async function merge(flow: FlowName): Promise<void> {
+  const rawPath = resolve(OUT_DIR, `${flow}.raw.jsonld`);
+  const finalPath = resolve(OUT_DIR, `${flow}.final.jsonld`);
+  const sidecarFlow = SIDECAR_FOR_FLOW[flow];
+
+  const doc = readJson<EPCISDoc>(rawPath);
+
+  if (sidecarFlow) {
+    const sidecarPath = resolve(FLOWS_DIR, `${sidecarFlow}.masterdata.jsonld`);
+    const sidecar = readJson<Sidecar>(sidecarPath);
+    const cards = (sidecar.masterData ?? []).map(transformCardForEvent);
+
+    const eventList = doc.epcisBody?.eventList ?? [];
+    if (eventList.length === 0) {
+      throw new Error(`merge(${flow}): generated document has no events`);
+    }
+    for (const event of eventList) {
+      event.masterDataAvailableFor = cards;
+    }
+    console.log(`merge ${flow}: spliced ${cards.length} cards into ${eventList.length} event(s)`);
+  } else {
+    console.log(`merge ${flow}: no sidecar (lifecycle event reuses already-registered master data)`);
+  }
+
+  writeJson(finalPath, doc);
+  console.log(`wrote ${finalPath}`);
+}
+
+const args = process.argv.slice(2);
+const targets = args.length > 0 ? (args as FlowName[]) : ALL_FLOWS;
+for (const flow of targets) await merge(flow);

--- a/demos/epcis-driven-dpp/scripts/run-flow.ts
+++ b/demos/epcis-driven-dpp/scripts/run-flow.ts
@@ -1,0 +1,43 @@
+/**
+ * Orchestrates one flow end-to-end:
+ *   seed-dlr  →  generate  →  merge-masterdata  →  capture  →  verify
+ *
+ * Steps that don't apply to lifecycle flows (no sidecar) are skipped.
+ * Capture / verify steps are skipped when SKIP_CLUSTER=1 (smoke-test mode
+ * against the public testdata-generator only).
+ */
+import { spawn } from 'node:child_process';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { ALL_FLOWS, type FlowName } from './lib/env.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+function run(script: string, flow: FlowName): Promise<void> {
+  return new Promise((resolveP, rejectP) => {
+    const child = spawn('tsx', [resolve(here, script), flow], {
+      stdio: 'inherit',
+      env: process.env,
+    });
+    child.on('exit', (code) => (code === 0 ? resolveP() : rejectP(new Error(`${script} exited ${code}`))));
+  });
+}
+
+const flow = process.argv[2] as FlowName | undefined;
+if (!flow || !ALL_FLOWS.includes(flow)) {
+  console.error(`Usage: tsx run-flow.ts <flow>\n  flows: ${ALL_FLOWS.join(', ')}`);
+  process.exit(2);
+}
+
+const skipCluster = process.env.SKIP_CLUSTER === '1';
+
+console.log(`==> ${flow}`);
+if (!skipCluster) await run('seed-dlr.ts', flow);
+await run('generate.ts', flow);
+await run('merge-masterdata.ts', flow);
+await run('to-designer.ts', flow);
+if (!skipCluster) {
+  await run('capture.ts', flow);
+  await run('verify.ts', flow);
+}
+console.log(`==> ${flow} done`);

--- a/demos/epcis-driven-dpp/scripts/seed-dlr.ts
+++ b/demos/epcis-driven-dpp/scripts/seed-dlr.ts
@@ -1,0 +1,106 @@
+/**
+ * Seed the local Digital Link Resolver (Colima k3s) with the master-data
+ * cards from each *.masterdata.jsonld sidecar.
+ *
+ * For each card:
+ *   1. PUT a Product / Place / Organization record (via the resolver's
+ *      product API — accepts JSON-LD with @JsonAnySetter for extensions).
+ *   2. POST a LinkSet with a gs1:masterData link pointing back at the
+ *      same Digital Link, so GET /<dl>?linkType=masterData returns the
+ *      card inline (200) instead of redirecting.
+ *
+ * The exact API path / verb is read from openepcis-build/modules/openepcis-digital-link-resolver/.
+ * As ground-truthed in our exploration:
+ *   POST /{digitalLinkSet}              — register link entries (LinkSet payload)
+ *   GET  /{digitalLink}?linkType=masterData → returns the master data card (application/ld+json)
+ *
+ * If the deployment differs (e.g. PUT vs POST, or the Product API is mounted
+ * separately), tweak the RESOLVER_PRODUCT_PATH / RESOLVER_LINKSET_PATH below.
+ */
+import { resolve } from 'node:path';
+import { readJson } from './lib/io.js';
+import { httpFetch, expectOk } from './lib/http.js';
+import { getAccessToken } from './lib/keycloak.js';
+import { FLOWS_DIR, getenv, SIDECAR_FOR_FLOW, ALL_FLOWS, type FlowName } from './lib/env.js';
+
+type Card = Record<string, unknown> & { id: string; type?: string };
+
+function pathFromGs1Url(url: string): string {
+  const u = new URL(url);
+  return u.pathname; // e.g. /01/09521234000013/21/BAT2024-001
+}
+
+async function putProduct(card: Card, token: string): Promise<void> {
+  const base = getenv('DLR_URL');
+  const dlPath = pathFromGs1Url(card.id);
+  const url = `${base}${dlPath}`;
+  const response = await httpFetch(url, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/ld+json',
+      Accept: 'application/ld+json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(card),
+  });
+  await expectOk(response, `seed-dlr PUT ${url}`);
+  console.log(`  PUT ${dlPath}  (${card.type ?? 'object'})`);
+}
+
+async function postLinkSet(card: Card, token: string): Promise<void> {
+  const base = getenv('DLR_URL');
+  const dlPath = pathFromGs1Url(card.id);
+  const url = `${base}${dlPath}`;
+  const linkSet = {
+    linkset: [
+      {
+        anchor: card.id,
+        itemDescription:
+          ((card['gs1:productName'] as { en?: string } | undefined)?.en) ??
+          ((card['gs1:physicalLocationName'] as { en?: string } | undefined)?.en) ??
+          ((card['gs1:organizationName'] as { en?: string } | undefined)?.en) ??
+          'OpenEPCIS DPP demo entry',
+        'gs1:masterData': [
+          {
+            href: `${dlPath}?linkType=gs1:masterData`,
+            title: 'Product master data',
+            type: 'application/ld+json',
+            hreflang: ['en'],
+          },
+        ],
+      },
+    ],
+  };
+  const response = await httpFetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(linkSet),
+  });
+  await expectOk(response, `seed-dlr POST ${url}`);
+  console.log(`  POST ${dlPath}  (linkset)`);
+}
+
+async function seedFlow(flow: FlowName): Promise<void> {
+  const sidecarFlow = SIDECAR_FOR_FLOW[flow];
+  if (!sidecarFlow) {
+    console.log(`seed-dlr ${flow}: no sidecar (lifecycle flow), skipping`);
+    return;
+  }
+  const sidecarPath = resolve(FLOWS_DIR, `${sidecarFlow}.masterdata.jsonld`);
+  const sidecar = readJson<{ masterData?: Card[] }>(sidecarPath);
+  const cards = sidecar.masterData ?? [];
+  console.log(`seed-dlr ${flow}: ${cards.length} card(s) from ${sidecarPath}`);
+
+  const token = await getAccessToken();
+  for (const card of cards) {
+    await putProduct(card, token);
+    await postLinkSet(card, token);
+  }
+}
+
+const args = process.argv.slice(2);
+const targets = args.length > 0 ? (args as FlowName[]) : ALL_FLOWS;
+for (const flow of targets) await seedFlow(flow);

--- a/demos/epcis-driven-dpp/scripts/to-designer.ts
+++ b/demos/epcis-driven-dpp/scripts/to-designer.ts
@@ -1,0 +1,276 @@
+/**
+ * Convert each flows/<flow>.input.json (the API InputTemplate shape that
+ * scripts/generate.ts POSTs to /api/generateTestData) into the
+ * Drawflow-design shape that
+ * https://tools.openepcis.io/ui/event-data-designer/?url=<raw-json> loads.
+ *
+ * The designer shape wraps each event as
+ *   eventNodeInfo[].eventInfo = { ...api event fields, +name, +description, +recordTimeOption, +errorDeclaration }
+ * and each identifier as
+ *   identifiersNodeInfo[] = { identifiersId, identifierType: "Identifiers", instanceType|classType, ... }
+ * plus connectorsInfo[] (input/output edges) and drawflowInfo (Vue Drawflow node positions).
+ *
+ * Reference: examples/Design Template for GS1 Implementation Guideline examples/*.json in
+ * openepcis/epcis-testdata-generator.
+ */
+import { readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { readJson, writeJson } from './lib/io.js';
+import { FLOWS_DIR } from './lib/env.js';
+
+type RefIdentifier = {
+  identifierId: number;
+  epcCount: number;
+  inheritParentCount: number;
+  classCount: number;
+  quantity: number;
+};
+
+type ApiEvent = {
+  nodeId: number;
+  eventType: string;
+  eventCount: number;
+  ordinaryEvent: boolean;
+  eventID?: boolean;
+  eventIdType?: string;
+  action?: string;
+  businessStep?: string;
+  disposition?: string;
+  locationPartyIdentifierSyntax?: string;
+  dlURL?: string;
+  eventTime: { specificTime: string; timeZoneOffset: string; fromTime?: string; toTime?: string };
+  readPoint?: Record<string, unknown>;
+  bizLocation?: Record<string, unknown>;
+  bizTransactions?: unknown[];
+  sources?: unknown[];
+  destinations?: unknown[];
+  referencedIdentifier?: RefIdentifier[];
+  parentReferencedIdentifier?: RefIdentifier | Record<string, never>;
+  outputReferencedIdentifier?: RefIdentifier[];
+  userExtensions?: unknown[];
+  certificationInfo?: unknown[];
+  ilmd?: unknown[];
+  persistentDispositionList?: unknown[];
+  sensorElementList?: unknown[];
+};
+
+type ApiIdentifier = {
+  identifierId: number;
+  objectIdentifierSyntax?: string;
+  dlURL?: string;
+  instanceData?: Record<string, { identifierType: string }> | null;
+  classData?: Record<string, { identifierType: string }> | null;
+  parentData?: Record<string, { identifierType: string }> | null;
+};
+
+type ApiTemplate = {
+  events: ApiEvent[];
+  identifiers: ApiIdentifier[];
+  contextUrls?: unknown[];
+  randomGenerators?: unknown[];
+  _comment?: string;
+};
+
+const DEFAULT_TIME = (api: ApiEvent['eventTime']) => ({
+  timeSelector: 'SpecificTime' as const,
+  specificTime: api.specificTime,
+  fromTime: api.fromTime ?? api.specificTime,
+  toTime: api.toTime ?? api.specificTime,
+  timeZoneOffset: api.timeZoneOffset,
+});
+
+function convert(api: ApiTemplate, flow: string) {
+  const eventNodeInfo = api.events.map((e) => ({
+    eventId: e.nodeId,
+    eventType: e.eventType,
+    eventInfo: {
+      objectIdentifierSyntax: 'WebURI',
+      locationPartyIdentifierSyntax: e.locationPartyIdentifierSyntax ?? 'WebURI',
+      dlURL: e.dlURL ?? 'https://id.gs1.org',
+      eventCount: e.eventCount,
+      eventTime: DEFAULT_TIME(e.eventTime),
+      parentIdentifier: [],
+      instanceIdentifier: [],
+      classIdentifier: [],
+      outputInstanceIdentifier: [],
+      outputClassIdentifier: [],
+      readPoint: e.readPoint ?? {},
+      bizLocation: e.bizLocation ?? {},
+      persistentDispositionList: e.persistentDispositionList ?? [],
+      bizTransactions: e.bizTransactions ?? [],
+      sources: e.sources ?? [],
+      destinations: e.destinations ?? [],
+      sensorElementList: e.sensorElementList ?? [],
+      userExtensions: e.userExtensions ?? [],
+      certificationInfo: e.certificationInfo ?? [],
+      ilmd: e.ilmd ?? [],
+      errorDeclaration: {
+        declarationTime: DEFAULT_TIME(e.eventTime),
+        correctiveIds: [],
+        extensions: [],
+        declarationReason: 'DID_NOT_OCCUR',
+      },
+      eventType: e.eventType,
+      ordinaryEvent: e.ordinaryEvent,
+      eventID: e.eventID ?? false,
+      eventIdType: e.eventIdType ?? 'UUID',
+      recordTimeOption: 'No',
+      ...(e.action ? { action: e.action } : {}),
+      businessStep: e.businessStep ?? 'NULL',
+      disposition: e.disposition ?? 'NULL',
+      referencedIdentifier: e.referencedIdentifier ?? [],
+      parentReferencedIdentifier: e.parentReferencedIdentifier ?? {},
+      outputReferencedIdentifier: e.outputReferencedIdentifier ?? [],
+      name: `${flow} (event ${e.nodeId})`,
+      description: `Auto-converted from flows/${flow}.input.json`,
+    },
+  }));
+
+  const identifiersNodeInfo = api.identifiers.map((i) => {
+    const out: Record<string, unknown> = {
+      identifiersId: i.identifierId,
+      identifierType: 'Identifiers',
+      objectIdentifierSyntax: i.objectIdentifierSyntax ?? 'WebURI',
+    };
+    if (i.dlURL) out.dlURL = i.dlURL;
+    if (i.instanceData) {
+      const k = Object.keys(i.instanceData)[0]!;
+      out.instanceType = k;
+      out.instanceData = (i.instanceData as Record<string, unknown>)[k];
+    } else if (i.classData) {
+      const k = Object.keys(i.classData)[0]!;
+      out.classType = k;
+      out.classData = (i.classData as Record<string, unknown>)[k];
+    } else if (i.parentData) {
+      const k = Object.keys(i.parentData)[0]!;
+      out.parentType = k;
+      out.parentData = (i.parentData as Record<string, unknown>)[k];
+    }
+    return out;
+  });
+
+  // Connectors: each referencedIdentifier becomes a connector from identifier → event,
+  // each outputReferencedIdentifier becomes a connector from identifier → event input_2.
+  let connId = 1;
+  const connectorsInfo: Array<{
+    ID: number;
+    name: string;
+    source: string;
+    target: string;
+    hideInheritParentCount: boolean;
+    epcCount: number;
+    inheritParentCount: number;
+    classCount: number;
+    quantity: number;
+  }> = [];
+  const inputConnectionsByEvent = new Map<number, Array<{ node: string; input: string }>>();
+  const outputConnectionsByEvent = new Map<number, Array<{ node: string; input: string }>>();
+  const identifierOutputs = new Map<number, Array<{ node: string; output: string }>>();
+
+  for (const e of api.events) {
+    for (const r of e.referencedIdentifier ?? []) {
+      connectorsInfo.push({
+        ID: connId++,
+        name: `connector${connectorsInfo.length + 1}`,
+        source: String(r.identifierId),
+        target: String(e.nodeId),
+        hideInheritParentCount: false,
+        epcCount: r.epcCount,
+        inheritParentCount: r.inheritParentCount,
+        classCount: r.classCount,
+        quantity: r.quantity,
+      });
+      const ic = inputConnectionsByEvent.get(e.nodeId) ?? [];
+      ic.push({ node: String(r.identifierId), input: 'output_1' });
+      inputConnectionsByEvent.set(e.nodeId, ic);
+      const oc = identifierOutputs.get(r.identifierId) ?? [];
+      oc.push({ node: String(e.nodeId), output: 'input_1' });
+      identifierOutputs.set(r.identifierId, oc);
+    }
+    for (const r of e.outputReferencedIdentifier ?? []) {
+      connectorsInfo.push({
+        ID: connId++,
+        name: `connector${connectorsInfo.length + 1}`,
+        source: String(r.identifierId),
+        target: String(e.nodeId),
+        hideInheritParentCount: false,
+        epcCount: r.epcCount,
+        inheritParentCount: r.inheritParentCount,
+        classCount: r.classCount,
+        quantity: r.quantity,
+      });
+      const oc = outputConnectionsByEvent.get(e.nodeId) ?? [];
+      oc.push({ node: String(r.identifierId), input: 'output_1' });
+      outputConnectionsByEvent.set(e.nodeId, oc);
+      const idOut = identifierOutputs.get(r.identifierId) ?? [];
+      idOut.push({ node: String(e.nodeId), output: 'input_2' });
+      identifierOutputs.set(r.identifierId, idOut);
+    }
+  }
+
+  // Drawflow auto-layout: identifiers on the left in a column, events on the right.
+  const drawflowData: Record<string, unknown> = {};
+  let posY = 100;
+  for (const i of api.identifiers) {
+    drawflowData[String(i.identifierId)] = {
+      id: i.identifierId,
+      name: 'Identifiers',
+      data: { ID: i.identifierId, eventType: 'Identifiers' },
+      class: 'Identifiers',
+      html: 'Identifiers',
+      typenode: 'vue',
+      inputs: {},
+      outputs: { output_1: { connections: identifierOutputs.get(i.identifierId) ?? [] } },
+      pos_x: 200,
+      pos_y: posY,
+    };
+    posY += 120;
+  }
+  let evtY = 200;
+  for (const e of api.events) {
+    drawflowData[String(e.nodeId)] = {
+      id: e.nodeId,
+      name: 'Events',
+      data: { ID: e.nodeId, eventType: e.eventType },
+      class: e.eventType,
+      html: 'Events',
+      typenode: 'vue',
+      inputs: {
+        input_1: { connections: inputConnectionsByEvent.get(e.nodeId) ?? [] },
+        input_2: { connections: outputConnectionsByEvent.get(e.nodeId) ?? [] },
+      },
+      outputs: { output_1: { connections: [] } },
+      pos_x: 800,
+      pos_y: evtY,
+    };
+    evtY += 200;
+  }
+
+  const designer: Record<string, unknown> = {
+    eventNodeInfo,
+    identifiersNodeInfo,
+    connectorsInfo,
+    drawflowInfo: { drawflow: { Home: { data: drawflowData } } },
+  };
+  if (api.contextUrls && api.contextUrls.length > 0) designer.contextUrls = api.contextUrls;
+  if (api.randomGenerators && api.randomGenerators.length > 0)
+    designer.randomGenerators = api.randomGenerators;
+
+  return designer;
+}
+
+const cliArgs = process.argv.slice(2);
+const flowFilter = new Set(cliArgs);
+const apiFiles = readdirSync(FLOWS_DIR)
+  .filter((f) => f.endsWith('.input.json') && !f.includes('designer'))
+  .filter((f) => flowFilter.size === 0 || flowFilter.has(f.replace(/\.input\.json$/, '')));
+
+for (const f of apiFiles) {
+  const flow = f.replace(/\.input\.json$/, '');
+  const apiPath = resolve(FLOWS_DIR, f);
+  const designerPath = resolve(FLOWS_DIR, 'designer', `${flow}.designer.json`);
+  const api = readJson<ApiTemplate>(apiPath);
+  const designer = convert(api, flow);
+  writeJson(designerPath, designer);
+  console.log(`converted ${f} → designer/${flow}.designer.json`);
+}

--- a/demos/epcis-driven-dpp/scripts/verify.ts
+++ b/demos/epcis-driven-dpp/scripts/verify.ts
@@ -1,0 +1,78 @@
+/**
+ * Read-back assertions per flow.
+ * Each step is intentionally tolerant — it logs PASS/FAIL/SKIP rather than
+ * throwing on the first failure, so an operator inspecting the demo can see
+ * which capabilities of the local cluster are wired up and which aren't.
+ */
+import { resolve } from 'node:path';
+import { readJson } from './lib/io.js';
+import { httpFetch } from './lib/http.js';
+import { getAccessToken } from './lib/keycloak.js';
+import { OUT_DIR, getenv, ALL_FLOWS, SIDECAR_FOR_FLOW, type FlowName } from './lib/env.js';
+
+type EPCISDoc = {
+  epcisBody?: { eventList?: { epcList?: string[]; outputEPCList?: string[] }[] };
+};
+
+function pathFromGs1Url(url: string): string {
+  return new URL(url).pathname;
+}
+
+function logResult(label: string, ok: boolean, detail = ''): void {
+  const tag = ok ? 'PASS' : 'FAIL';
+  console.log(`  [${tag}] ${label}${detail ? ` — ${detail}` : ''}`);
+}
+
+async function verifyDlr(flow: FlowName): Promise<void> {
+  const sidecarFlow = SIDECAR_FOR_FLOW[flow];
+  if (!sidecarFlow) return;
+  const sidecar = readJson<{ masterData?: { id: string; type?: string }[] }>(
+    resolve(OUT_DIR, '..', 'flows', `${sidecarFlow}.masterdata.jsonld`)
+  );
+  const base = getenv('DLR_URL');
+  const token = await getAccessToken().catch(() => '');
+
+  for (const card of sidecar.masterData ?? []) {
+    const url = `${base}${pathFromGs1Url(card.id)}?linkType=gs1:masterData`;
+    const response = await httpFetch(url, {
+      headers: {
+        Accept: 'application/ld+json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+    });
+    logResult(`DLR ${pathFromGs1Url(card.id)}`, response.ok, `status=${response.status}`);
+  }
+}
+
+async function verifyEvents(flow: FlowName): Promise<void> {
+  const finalPath = resolve(OUT_DIR, `${flow}.final.jsonld`);
+  const doc = readJson<EPCISDoc>(finalPath);
+  const epcs = new Set<string>();
+  for (const event of doc.epcisBody?.eventList ?? []) {
+    for (const epc of event.epcList ?? []) epcs.add(epc);
+    for (const epc of event.outputEPCList ?? []) epcs.add(epc);
+  }
+  const base = getenv('EPCIS_API_URL');
+  const token = await getAccessToken().catch(() => '');
+
+  for (const epc of epcs) {
+    const url = `${base}/events?MATCH_anyEPC=${encodeURIComponent(epc)}`;
+    const response = await httpFetch(url, {
+      headers: {
+        Accept: 'application/ld+json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+    });
+    logResult(`Repository query for ${epc}`, response.ok, `status=${response.status}`);
+  }
+}
+
+async function verify(flow: FlowName): Promise<void> {
+  console.log(`verify ${flow}`);
+  await verifyDlr(flow);
+  await verifyEvents(flow);
+}
+
+const args = process.argv.slice(2);
+const targets = args.length > 0 ? (args as FlowName[]) : ALL_FLOWS;
+for (const flow of targets) await verify(flow);

--- a/demos/epcis-driven-dpp/tsconfig.json
+++ b/demos/epcis-driven-dpp/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "skipLibCheck": true,
+    "lib": ["ES2022"],
+    "types": ["node"]
+  },
+  "include": ["scripts/**/*.ts"]
+}


### PR DESCRIPTION
Four flows that prove an OpenEPCIS DPP-Ready deployment can register GTIN/GLN identifiers in a GS1 conformant Digital Link Resolver and update their DPP master data via captured EPCIS 2.0 events.

Pipeline: tools.openepcis.io test data generator (public) → masterdata merge → /capture on local Colima k3s deployment of openepcis-platform. Flows include initial commission and lifecycle update for both battery (stateOfHealth) and textile (garment transform + durability assessment).

Adds Drawflow-design companions under flows/designer/ that load directly into https://tools.openepcis.io/ui/event-data-designer/?url=… plus a designer-urls helper to print the per-flow URLs.