### PR TITLE
feat(types): narrow demo seed type discriminators; add battery:Batter…

### DIFF
--- a/extensions/eu/battery/context/battery-context.jsonld
+++ b/extensions/eu/battery/context/battery-context.jsonld
@@ -55,6 +55,7 @@
       "regulatoryPermitIdentification": "gs1:regulatoryPermitIdentification",
       "isRegulationCompliant": "gs1:isRegulationCompliant",
       "regulatoryInformationProvider": "gs1:regulatoryInformationProvider",
+      "Battery": "battery:Battery",
       "BatteryChemistry": "battery:BatteryChemistry",
       "TechnicalSpecification": "battery:TechnicalSpecification",
       "BatteryMaterial": "battery:BatteryMaterial",

--- a/extensions/eu/battery/examples/battery-product.jsonld
+++ b/extensions/eu/battery/examples/battery-product.jsonld
@@ -19,7 +19,10 @@
     }
   ],
   "id": "https://id.gs1.org/01/09521234000013/21/BAT2024-001",
-  "type": "Product",
+  "type": [
+    "Product",
+    "Battery"
+  ],
   "gtin": "09521234000013",
   "gs1:serialNumber": "BAT2024-001",
   "productName": {

--- a/extensions/eu/battery/examples/portable-ebike-battery.jsonld
+++ b/extensions/eu/battery/examples/portable-ebike-battery.jsonld
@@ -16,7 +16,10 @@
     }
   ],
   "id": "https://id.gs1.org/01/09521234000044/21/EB2026-00821",
-  "type": "Product",
+  "type": [
+    "Product",
+    "Battery"
+  ],
   "gtin": "09521234000044",
   "gs1:serialNumber": "EB2026-00821",
   "productName": {
@@ -203,10 +206,26 @@
     "type": "EndOfLifeInfo",
     "recyclabilityRate": 78,
     "materialRecoveryTargets": [
-      { "type": "MaterialRecoveryTarget", "recoveryMaterial": "Lithium", "recoveryRate": 50 },
-      { "type": "MaterialRecoveryTarget", "recoveryMaterial": "Cobalt",  "recoveryRate": 90 },
-      { "type": "MaterialRecoveryTarget", "recoveryMaterial": "Nickel",  "recoveryRate": 90 },
-      { "type": "MaterialRecoveryTarget", "recoveryMaterial": "Copper",  "recoveryRate": 95 }
+      {
+        "type": "MaterialRecoveryTarget",
+        "recoveryMaterial": "Lithium",
+        "recoveryRate": 50
+      },
+      {
+        "type": "MaterialRecoveryTarget",
+        "recoveryMaterial": "Cobalt",
+        "recoveryRate": 90
+      },
+      {
+        "type": "MaterialRecoveryTarget",
+        "recoveryMaterial": "Nickel",
+        "recoveryRate": 90
+      },
+      {
+        "type": "MaterialRecoveryTarget",
+        "recoveryMaterial": "Copper",
+        "recoveryRate": 95
+      }
     ]
   },
   "dismantlingDocuments": [

--- a/extensions/eu/battery/ontology/battery.ttl
+++ b/extensions/eu/battery/ontology/battery.ttl
@@ -75,6 +75,14 @@ Battery categories can also be expressed via gs1:additionalProductClassification
 # PART 1: CORE CLASSES
 # =============================================================================
 
+battery:Battery
+    a owl:Class ;
+    rdfs:label "Battery"@en ;
+    rdfs:comment "A self-contained energy-storage device whose Digital Product Passport falls in scope of EU Regulation 2023/1542. Use as the primary `type` discriminator on a Battery product (typically paired with `gs1:Product` for canonical JSON-LD dual-typing, e.g. `\"type\": [\"Product\", \"Battery\"]`). Subclasses on battery:batteryCategory (LMTBattery, EVBattery, IndustrialBattery, StationaryBattery, PortableBattery, SLIBattery) further qualify the category."@en ;
+    rdfs:subClassOf gs1:Product ;
+    dcterms:source <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32023R1542> ;
+    rdfs:isDefinedBy <https://ref.openepcis.io/extensions/eu/battery/> .
+
 battery:BatteryChemistry
     a owl:Class ;
     rdfs:label "Battery Chemistry"@en ;

--- a/extensions/eu/textile/examples/footwear-product.jsonld
+++ b/extensions/eu/textile/examples/footwear-product.jsonld
@@ -19,7 +19,7 @@
   ],
   "id": "https://id.gs1.org/01/09521234300021/21/TR-2024-08521",
   "type": [
-    "Product",
+    "Footwear",
     "TextileFootwear"
   ],
   "gtin": "09521234300021",

--- a/extensions/eu/textile/examples/garment-product.jsonld
+++ b/extensions/eu/textile/examples/garment-product.jsonld
@@ -21,7 +21,7 @@
   ],
   "id": "https://id.gs1.org/01/09521234300014/21/WJ-2024-00142",
   "type": [
-    "Product",
+    "Clothing",
     "TextileApparel"
   ],
   "gtin": "09521234300014",

--- a/extensions/eu/textile/examples/garment-set-itip.jsonld
+++ b/extensions/eu/textile/examples/garment-set-itip.jsonld
@@ -21,7 +21,7 @@
   ],
   "id": "https://id.gs1.org/01/09521234000075/21/SUIT-2026-00042",
   "type": [
-    "Product",
+    "Clothing",
     "TextileApparel"
   ],
   "gtin": "09521234000075",


### PR DESCRIPTION
…y class

Two coupled changes — the type-narrowing on the seeds depends on the new battery:Battery class being grounded in the ontology + context.

== Seed type narrowing ==

Demo examples now use the most-specific GS1 (or extension) class as the head of the JSON-LD type array, matching the canonical dual-typing convention used by ref.openepcis.io examples:

  garment-product            ['Product', 'TextileApparel'] -> ['Clothing', 'TextileApparel']
  footwear-product           ['Product', 'TextileFootwear'] -> ['Footwear', 'TextileFootwear']
  garment-set-itip           ['Product', 'TextileApparel'] -> ['Clothing', 'TextileApparel']
  battery-product            'Product' -> ['Product', 'Battery']
  portable-ebike-battery     'Product' -> ['Product', 'Battery']

Unchanged: hometextile-bedlinen (no closer GS1 Apparel subclass than Product; TextileApparel already covers the home-textile sub-discriminator), beverage-bottle / multi-layer-pouch / ecommerce-carton (single-typed 'Packaging' is already the most-specific class for a PPWR DPP).

The openepcis DLR's new KnownProductTypeRegistry (refactor 28) validates every class in the array against a closed set; refactor 29 stores the full array as Postgres text[] so the dual-typing survives end-to-end.

== battery:Battery class ==

Adds 'battery:Battery (subClassOf gs1:Product)' to the battery ontology and context. Previously the seeds typed batteries as just 'Product' — correct but uninformative; the discriminator that distinguishes them from any other product was carried only by namespace-specific properties (batteryChemistry, batteryCategory, etc.). With battery:Battery, a consumer can dispatch on the type discriminator alone.

  battery.ttl:    new battery:Battery class with rdfs:subClassOf gs1:Product
                  and dcterms:source pointing at EU Regulation 2023/1542
  battery-context.jsonld: 'Battery' alias maps to 'battery:Battery'

Verified against dev: 9/9 demo products round-trip; outbound JSON-LD type field emits the canonical compact form (scalar when 1 class, array when 2+):

  Alpine Pro Winter Jacket    type: ['Clothing', 'TextileApparel']
  EcoCell Industrial Battery  type: ['Product', 'Battery']
  EcoFlow Carton              type: 'Packaging'