### PR TITLE
chore(battery): regenerate battery.json with new Battery class

### DIFF
--- a/extensions/eu/battery/json/battery.json
+++ b/extensions/eu/battery/json/battery.json
@@ -5,6 +5,16 @@
   "description": "Battery-specific vocabulary extending GS1 Web Vocabulary for Digital Product Passports.\n\nA lightweight, 100% JSON-LD compatible alternative to BatteryPass/SAMM that covers all\nEU Battery Regulation 2023/1542 Annex XIII requirements while leveraging existing GS1 standards.\n\nAligned with:\n- EU Battery Regulation 2023/1542 Annex XIII\n- DIN DKE SPEC 99100:2025-02\n- GS1 Web Vocabulary (gs1:regulatoryInformation pattern)\n- GS1 EPCIS 2.0 (gs1:masterDataAvailableFor)\n\nGS1 Properties to Use (not redefined here):\n- gs1:gtin - Global Trade Item Number\n- gs1:netWeight / gs1:grossWeight - Battery weight\n- gs1:manufacturingDate - Manufacturing date\n- gs1:countryOfOrigin - Country of manufacture\n- gs1:manufacturer - Manufacturer organization\n- gs1:warranty / gs1:WarrantyPromise - Warranty information\n- gs1:certification / gs1:CertificationDetails - Certifications\n- gs1:regulatoryInformation - Regulatory compliance\n\nFor regulatory compliance data, use gs1:regulatoryInformation with gs1:RegulationTypeCode-BATTERY_DIRECTIVE.\n\nEPCIS 2.0 Extension Declaration:\nGS1-Extensions: battery=https://ref.openepcis.io/extensions/eu/battery/\n\nExtension Governance:\nThis vocabulary extends GS1 Web Vocabulary only where no equivalent term exists.\nEach extension term includes dcterms:source, skos:note, and rdfs:seeAlso where applicable.\nBattery categories can also be expressed via gs1:additionalProductClassification.",
   "classes": [
     {
+      "id": "https://ref.openepcis.io/extensions/eu/battery/Battery",
+      "localName": "Battery",
+      "label": "Battery",
+      "comment": "A self-contained energy-storage device whose Digital Product Passport falls in scope of EU Regulation 2023/1542. Use as the primary `type` discriminator on a Battery product (typically paired with `gs1:Product` for canonical JSON-LD dual-typing, e.g. `\"type\": [\"Product\", \"Battery\"]`). Subclasses on battery:batteryCategory (LMTBattery, EVBattery, IndustrialBattery, StationaryBattery, PortableBattery, SLIBattery) further qualify the category.",
+      "subClassOf": [
+        "https://ref.gs1.org/voc/Product"
+      ],
+      "source": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32023R1542"
+    },
+    {
       "id": "https://ref.openepcis.io/extensions/eu/battery/BatteryChemistry",
       "localName": "BatteryChemistry",
       "label": "Battery Chemistry",


### PR DESCRIPTION
Auto-generated output from `pnpm run build` after adding battery:Battery to the ontology. Keeps json/battery.json in sync with ontology/battery.ttl so the published ref.openepcis.io mirror picks it up.